### PR TITLE
fix: use the getStringProperty method of the DataAddress

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -91,7 +91,7 @@ maven/mavencentral/io.grpc/grpc-auth/1.56.1, Apache-2.0, approved, clearlydefine
 maven/mavencentral/io.grpc/grpc-context/1.27.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.grpc/grpc-context/1.56.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.grpc/grpc-core/1.56.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.grpc/grpc-googleapis/1.56.1, , restricted, clearlydefined
+maven/mavencentral/io.grpc/grpc-googleapis/1.56.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.grpc/grpc-grpclb/1.56.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.grpc/grpc-netty-shaded/1.56.1, Apache-2.0, restricted, clearlydefined
 maven/mavencentral/io.grpc/grpc-protobuf-lite/1.56.1, Apache-2.0, approved, clearlydefined
@@ -103,9 +103,9 @@ maven/mavencentral/io.grpc/grpc-xds/1.56.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.opencensus/opencensus-api/0.31.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.opencensus/opencensus-contrib-http-util/0.31.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.opencensus/opencensus-proto/0.2.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.28.0, Apache-2.0, approved, #9662
-maven/mavencentral/io.opentelemetry/opentelemetry-api/1.28.0, Apache-2.0, approved, #9661
-maven/mavencentral/io.opentelemetry/opentelemetry-context/1.28.0, Apache-2.0, approved, #9663
+maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.29.0, , restricted, clearlydefined
+maven/mavencentral/io.opentelemetry/opentelemetry-api/1.29.0, , restricted, clearlydefined
+maven/mavencentral/io.opentelemetry/opentelemetry-context/1.29.0, , restricted, clearlydefined
 maven/mavencentral/io.perfmark/perfmark-api/0.26.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.0, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsConsumerResourceDefinitionGenerator.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsConsumerResourceDefinitionGenerator.java
@@ -32,8 +32,8 @@ public class GcsConsumerResourceDefinitionGenerator implements ConsumerResourceD
     ResourceDefinition generate(DataRequest dataRequest, Policy policy) {
         var destination = dataRequest.getDataDestination();
         var id = randomUUID().toString();
-        var location = destination.getProperty(GcsStoreSchema.LOCATION);
-        var storageClass = destination.getProperty(GcsStoreSchema.STORAGE_CLASS);
+        var location = destination.getStringProperty(GcsStoreSchema.LOCATION);
+        var storageClass = destination.getStringProperty(GcsStoreSchema.STORAGE_CLASS);
 
         return GcsResourceDefinition.Builder.newInstance().id(id).location(location)
                 .storageClass(storageClass).build();

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionedResource.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionedResource.java
@@ -35,23 +35,23 @@ public class GcsProvisionedResource extends ProvisionedDataDestinationResource {
     }
 
     public String getBucketName() {
-        return getDataAddress().getProperty(BUCKET_NAME);
+        return getDataAddress().getStringProperty(BUCKET_NAME);
     }
 
     public String getLocation() {
-        return getDataAddress().getProperty(LOCATION);
+        return getDataAddress().getStringProperty(LOCATION);
     }
 
     public String getStorageClass() {
-        return getDataAddress().getProperty(STORAGE_CLASS);
+        return getDataAddress().getStringProperty(STORAGE_CLASS);
     }
 
     public String getServiceAccountName() {
-        return getDataAddress().getProperty(SERVICE_ACCOUNT_NAME);
+        return getDataAddress().getStringProperty(SERVICE_ACCOUNT_NAME);
     }
 
     public String getServiceAccountEmail() {
-        return getDataAddress().getProperty(SERVICE_ACCOUNT_EMAIL);
+        return getDataAddress().getStringProperty(SERVICE_ACCOUNT_EMAIL);
     }
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSinkFactory.java
@@ -79,8 +79,8 @@ public class GcsDataSinkFactory implements DataSinkFactory {
 
         return GcsDataSink.Builder.newInstance()
                 .storageClient(storageClient)
-                .bucketName(destination.getProperty(GcsStoreSchema.BUCKET_NAME))
-                .blobName(destination.getProperty(GcsStoreSchema.BLOB_NAME))
+                .bucketName(destination.getStringProperty(GcsStoreSchema.BUCKET_NAME))
+                .blobName(destination.getStringProperty(GcsStoreSchema.BLOB_NAME))
                 .requestId(request.getId())
                 .executorService(executorService)
                 .monitor(monitor)

--- a/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSourceFactory.java
+++ b/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSourceFactory.java
@@ -61,8 +61,8 @@ public class GcsDataSourceFactory implements DataSourceFactory {
 
         return GcsDataSource.Builder.newInstance()
                 .storageClient(storageClient)
-                .bucketName(source.getProperty(GcsStoreSchema.BUCKET_NAME))
-                .blobName(source.getProperty(GcsStoreSchema.BLOB_NAME))
+                .bucketName(source.getStringProperty(GcsStoreSchema.BUCKET_NAME))
+                .blobName(source.getStringProperty(GcsStoreSchema.BLOB_NAME))
                 .monitor(monitor)
                 .build();
 

--- a/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/validation/GcsSinkDataAddressValidationRule.java
+++ b/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/validation/GcsSinkDataAddressValidationRule.java
@@ -21,12 +21,11 @@ import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.eclipse.edc.gcp.storage.GcsStoreSchema.BUCKET_NAME;
 
 public class GcsSinkDataAddressValidationRule implements ValidationRule<DataAddress> {
-    private final CompositeValidationRule<Map<String, String>> mandatoryPropertyValidationRule = new CompositeValidationRule<>(
+    private final CompositeValidationRule<DataAddress> mandatoryPropertyValidationRule = new CompositeValidationRule<>(
             List.of(
                     new EmptyValueValidationRule(BUCKET_NAME)
             )
@@ -34,6 +33,6 @@ public class GcsSinkDataAddressValidationRule implements ValidationRule<DataAddr
 
     @Override
     public Result<Void> apply(DataAddress dataAddress) {
-        return mandatoryPropertyValidationRule.apply(dataAddress.getProperties());
+        return mandatoryPropertyValidationRule.apply(dataAddress);
     }
 }

--- a/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/validation/GcsSourceDataAddressValidationRule.java
+++ b/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/validation/GcsSourceDataAddressValidationRule.java
@@ -21,14 +21,13 @@ import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.eclipse.edc.gcp.storage.GcsStoreSchema.BLOB_NAME;
 import static org.eclipse.edc.gcp.storage.GcsStoreSchema.BUCKET_NAME;
 
 public class GcsSourceDataAddressValidationRule implements ValidationRule<DataAddress> {
 
-    private final CompositeValidationRule<Map<String, String>> mandatoryPropertyValidationRule  = new CompositeValidationRule<>(
+    private final CompositeValidationRule<DataAddress> mandatoryPropertyValidationRule  = new CompositeValidationRule<>(
             List.of(
                     new EmptyValueValidationRule(BLOB_NAME),
                     new EmptyValueValidationRule(BUCKET_NAME)
@@ -37,6 +36,6 @@ public class GcsSourceDataAddressValidationRule implements ValidationRule<DataAd
 
     @Override
     public Result<Void> apply(DataAddress dataAddress) {
-        return mandatoryPropertyValidationRule.apply(dataAddress.getProperties());
+        return mandatoryPropertyValidationRule.apply(dataAddress);
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Fixes compile errors that arose due to the `getProperty` -> `getStringProperty` transition in the `DataAddress` class.

## Why it does that

compile errors

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_
