### PR TITLE
feat: GCS provisioner accepts optional bucket name from transfer request

### DIFF
--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/StorageService.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/StorageService.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.gcp.storage;
 
-import com.google.cloud.storage.Storage;
 import org.eclipse.edc.gcp.common.GcpServiceAccount;
 import org.eclipse.edc.gcp.common.GcsBucket;
 
@@ -24,15 +23,15 @@ import org.eclipse.edc.gcp.common.GcsBucket;
 public interface StorageService {
 
     /**
-     * Creates a new bucket with the given name and location.
-     * If the bucket exists in the correct location and is empty it is returned.
-     * Else an Exception is thrown.
+     * Checks if a bucket with the given name exists in the specific location,
+     * and returns it. Otherwise, if no bucket with the given name exists,
+     * creates it.
      *
-     * @param bucketName The name of the bucket
-     * @param location   The location where the data in the bucket will be stored
-     * @return {@link Storage}
+     * @param bucketName The name of the bucket, must be unique in GCP
+     * @param location   The location of the bucket (e.g. "EUROPE-WEST3", "EU")
+     * @return {@link GcsBucket}
      */
-    GcsBucket getOrCreateEmptyBucket(String bucketName, String location);
+    GcsBucket getOrCreateBucket(String bucketName, String location);
 
     /**
      * Attaches a new role binding to the bucket that grants the service account the specified role on the bucket

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/StorageServiceImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/StorageServiceImpl.java
@@ -37,7 +37,7 @@ public class StorageServiceImpl implements StorageService {
     }
 
     @Override
-    public GcsBucket getOrCreateEmptyBucket(String bucketName, String location) {
+    public GcsBucket getOrCreateBucket(String bucketName, String location) {
         var bucket = Optional.ofNullable(storageClient.get(bucketName))
                 .orElseGet(() -> {
                     monitor.debug("Creating new bucket " + bucketName);

--- a/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/storage/StorageServiceImplTest.java
+++ b/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/storage/StorageServiceImplTest.java
@@ -62,7 +62,7 @@ class StorageServiceImplTest {
 
         when(storageMock.create(eq(expectedBucketInfo))).thenReturn(expectedBucket);
 
-        assertThat(storageService.getOrCreateEmptyBucket(bucketName, bucketLocation).getName()).isEqualTo(bucketName);
+        assertThat(storageService.getOrCreateBucket(bucketName, bucketLocation).getName()).isEqualTo(bucketName);
     }
 
     @Test
@@ -76,7 +76,7 @@ class StorageServiceImplTest {
 
         when(storageMock.get(bucketName)).thenReturn(existingBucket);
 
-        assertThat(storageService.getOrCreateEmptyBucket(bucketName, bucketLocation).getName()).isEqualTo(bucketName);
+        assertThat(storageService.getOrCreateBucket(bucketName, bucketLocation).getName()).isEqualTo(bucketName);
     }
 
     @Test
@@ -90,7 +90,7 @@ class StorageServiceImplTest {
 
         when(storageMock.get(bucketName)).thenReturn(existingBucket);
 
-        assertThatThrownBy(() -> storageService.getOrCreateEmptyBucket(bucketName, bucketLocation)).isInstanceOf(GcpException.class);
+        assertThatThrownBy(() -> storageService.getOrCreateBucket(bucketName, bucketLocation)).isInstanceOf(GcpException.class);
     }
 
     @Test

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsConsumerResourceDefinitionGenerator.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsConsumerResourceDefinitionGenerator.java
@@ -34,9 +34,10 @@ public class GcsConsumerResourceDefinitionGenerator implements ConsumerResourceD
         var id = randomUUID().toString();
         var location = destination.getStringProperty(GcsStoreSchema.LOCATION);
         var storageClass = destination.getStringProperty(GcsStoreSchema.STORAGE_CLASS);
+        var bucketName = destination.getStringProperty(GcsStoreSchema.BUCKET_NAME);
 
         return GcsResourceDefinition.Builder.newInstance().id(id).location(location)
-                .storageClass(storageClass).build();
+                .storageClass(storageClass).bucketName(bucketName).build();
     }
 
     @Override

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsResourceDefinition.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsResourceDefinition.java
@@ -22,6 +22,7 @@ public class GcsResourceDefinition extends ResourceDefinition {
 
     private String location;
     private String storageClass;
+    private String bucketName;
 
     private GcsResourceDefinition() {
     }
@@ -34,11 +35,16 @@ public class GcsResourceDefinition extends ResourceDefinition {
         return this.storageClass;
     }
 
+    public String getBucketName() {
+        return this.bucketName;
+    }
+
     @Override
     public Builder toBuilder() {
         return initializeBuilder(new Builder())
                 .location(location)
-                .storageClass(storageClass);
+                .storageClass(storageClass)
+                .bucketName(bucketName);
     }
 
     public static class Builder extends ResourceDefinition.Builder<GcsResourceDefinition, Builder> {
@@ -61,9 +67,16 @@ public class GcsResourceDefinition extends ResourceDefinition {
             return this;
         }
 
+        public Builder bucketName(String bucketName) {
+            resourceDefinition.bucketName = bucketName;
+            return this;
+        }
+
         @Override
         protected void verify() {
             super.verify();
+            // Bucket name is not required: if not present, provisioner generates a new one
+            // using the transfer id.
             Objects.requireNonNull(resourceDefinition.location, "location");
             Objects.requireNonNull(resourceDefinition.storageClass, "storageClass");
         }

--- a/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSink.java
+++ b/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSink.java
@@ -46,7 +46,7 @@ public class GcsDataSink extends ParallelSink {
                 var sinkBlobName = Optional.ofNullable(blobName)
                         .orElseGet(part::name);
                 var destinationBlobInfo = BlobInfo.newBuilder(BlobId.of(bucketName, sinkBlobName)).build();
-                try (var writer = storageClient.writer(destinationBlobInfo)) {
+                try (var writer = storageClient.writer(destinationBlobInfo, Storage.BlobWriteOption.doesNotExist())) {
                     ByteStreams.copy(input, Channels.newOutputStream(writer));
                 }
             } catch (IOException e) {


### PR DESCRIPTION
## What this PR changes/adds

- if the bucket name is not specific in the transfer request (bucket_name in dataAddress), the bucket name to store the destination blob is generated at runtime using the transfer id (same as before), otherwise the name passed is used (new feature)
- GCS provisioner gets (or creates if not-existing) the specific bucket
- GCS sink writes the blob in the provisioned bucket only in case it doesn't overwrite an existing blob with the same name

## Why it does that

The reuse of an existing bucket is a common use case for the GCS connector.

## Further notes

In case the destination bucket exists, and is not empty, the blob is transferred if there is no existing blob with the same name in the bucket.

## Linked Issue(s)

Closes #42
