### PR TITLE
feat: GCS status checker

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -118,7 +118,7 @@ maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.0, EPL-2.0 OR B
 maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
 maven/mavencentral/jakarta.inject/jakarta.inject-api/2.0.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.0, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7697
-maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, ee4j.validation
 maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.rest
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/javax.annotation/javax.annotation-api/1.3.2, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ16910
@@ -260,7 +260,6 @@ maven/mavencentral/org.slf4j/slf4j-api/1.7.25, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.30, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.36, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/2.0.5, MIT, approved, #5915
-maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.0, MIT, approved, #10344
 maven/mavencentral/org.testcontainers/testcontainers/1.19.0, Apache-2.0 AND MIT, approved, #10347
 maven/mavencentral/org.threeten/threetenbp/1.6.8, BSD-3-Clause, approved, #6750

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/StorageService.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/StorageService.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.gcp.storage;
 
+import com.google.api.gax.paging.Page;
+import com.google.cloud.storage.Blob;
 import org.eclipse.edc.gcp.common.GcpServiceAccount;
 import org.eclipse.edc.gcp.common.GcsBucket;
 
@@ -65,4 +67,12 @@ public interface StorageService {
      * @return true if the bucket is empty and false if not
      */
     boolean isEmpty(String bucketName);
+
+    /**
+     * Returns the list of Blobs in the bucket
+     *
+     * @param bucketName The name of the bucket
+     * @return the list of Blob items stored in the bucket
+     */
+    Page<Blob> list(String bucketName);
 }

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/StorageServiceImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/StorageServiceImpl.java
@@ -14,7 +14,9 @@
 
 package org.eclipse.edc.gcp.storage;
 
+import com.google.api.gax.paging.Page;
 import com.google.cloud.Binding;
+import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import org.eclipse.edc.gcp.common.GcpException;
@@ -90,5 +92,10 @@ public class StorageServiceImpl implements StorageService {
     public boolean isEmpty(String bucket) {
         var blobs = storageClient.list(bucket, Storage.BlobListOption.pageSize(1)).getValues();
         return !blobs.iterator().hasNext();
+    }
+
+    @Override
+    public Page<Blob> list(String bucketName) {
+        return storageClient.list(bucketName);
     }
 }

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionExtension.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionExtension.java
@@ -18,13 +18,14 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager;
 import org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestGenerator;
+import org.eclipse.edc.connector.transfer.spi.status.StatusCheckerRegistry;
 import org.eclipse.edc.gcp.iam.IamServiceImpl;
+import org.eclipse.edc.gcp.storage.GcsStoreSchema;
 import org.eclipse.edc.gcp.storage.StorageServiceImpl;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-
 
 public class GcsProvisionExtension implements ServiceExtension {
 
@@ -37,6 +38,9 @@ public class GcsProvisionExtension implements ServiceExtension {
     @Inject
     private ResourceManifestGenerator manifestGenerator;
 
+    @Inject
+    private StatusCheckerRegistry statusCheckerRegistry;
+
     @Override
     public String name() {
         return "GCP storage provisioner";
@@ -45,16 +49,14 @@ public class GcsProvisionExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var monitor = context.getMonitor();
-
         var projectId = context.getConfig().getString(GCP_PROJECT_ID);
         var storageClient = createDefaultStorageClient(projectId);
         var storageService = new StorageServiceImpl(storageClient, monitor);
         var iamService = IamServiceImpl.Builder.newInstance(monitor, projectId).build();
 
-        var provisioner = new GcsProvisioner(monitor, storageService, iamService);
-        provisionManager.register(provisioner);
-
+        provisionManager.register(new GcsProvisioner(monitor, storageService, iamService));
         manifestGenerator.registerGenerator(new GcsConsumerResourceDefinitionGenerator());
+        statusCheckerRegistry.register(GcsStoreSchema.TYPE, new GcsProvisionerStatusChecker(storageService));
     }
 
 

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisioner.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisioner.java
@@ -105,9 +105,9 @@ public class GcsProvisioner implements Provisioner<GcsResourceDefinition, GcsPro
                         .provisionedResourceId(provisionedResource.getId()).build()));
     }
 
-    private GcpServiceAccount createServiceAccount(String processId, String buckedName) {
+    private GcpServiceAccount createServiceAccount(String processId, String bucketName) {
         var serviceAccountName = sanitizeServiceAccountName(processId);
-        var uniqueServiceAccountDescription = generateUniqueServiceAccountDescription(processId, buckedName);
+        var uniqueServiceAccountDescription = generateUniqueServiceAccountDescription(processId, bucketName);
         return iamService.getOrCreateServiceAccount(serviceAccountName, uniqueServiceAccountDescription);
     }
 

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerStatusChecker.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerStatusChecker.java
@@ -18,14 +18,14 @@ import org.eclipse.edc.connector.transfer.spi.types.ProvisionedResource;
 import org.eclipse.edc.connector.transfer.spi.types.StatusChecker;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.gcp.storage.GcsStoreSchema;
-import org.eclipse.edc.gcp.storage.StorageServiceImpl;
+import org.eclipse.edc.gcp.storage.StorageService;
 
 import java.util.List;
 
 public class GcsProvisionerStatusChecker implements StatusChecker {
-    private StorageServiceImpl storageService;
+    private StorageService storageService;
 
-    public GcsProvisionerStatusChecker(StorageServiceImpl storageService) {
+    public GcsProvisionerStatusChecker(StorageService storageService) {
         this.storageService = storageService;
     }
 

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerStatusChecker.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerStatusChecker.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2023 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LCC - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.connector.provision.gcp;
+
+import org.eclipse.edc.connector.transfer.spi.types.ProvisionedResource;
+import org.eclipse.edc.connector.transfer.spi.types.StatusChecker;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.gcp.storage.GcsStoreSchema;
+import org.eclipse.edc.gcp.storage.StorageServiceImpl;
+
+import java.util.List;
+
+public class GcsProvisionerStatusChecker implements StatusChecker {
+    private StorageServiceImpl storageService;
+
+    public GcsProvisionerStatusChecker(StorageServiceImpl storageService) {
+        this.storageService = storageService;
+    }
+
+    @Override
+    public boolean isComplete(TransferProcess transferProcess, List<ProvisionedResource> resources) {
+        if (resources != null && !resources.isEmpty()) {
+            return resources.stream().allMatch(resource -> isResourceTransferCompleted(resource));
+        } else {
+            var bucketName = transferProcess.getDataRequest().getDataDestination().getStringProperty(GcsStoreSchema.BUCKET_NAME);
+            return isBucketTransferCompleted(bucketName);
+        }
+    }
+
+    private boolean isResourceTransferCompleted(ProvisionedResource resource) {
+        if (!(resource instanceof GcsProvisionedResource)) {
+            // Only handle GCS resources.
+            return true;
+        }
+        return isBucketTransferCompleted(((GcsProvisionedResource) resource).getBucketName());
+    }
+
+    private boolean isBucketTransferCompleted(String bucketName) {
+        var testBlobName = bucketName + ".complete";
+        var blobs = storageService.list(bucketName);
+        return blobs.streamAll().anyMatch(blob -> blob.getName().equals(testBlobName));
+    }
+}

--- a/extensions/control-plane/provision/provision-gcs/src/test/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerStatusCheckerTest.java
+++ b/extensions/control-plane/provision/provision-gcs/src/test/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerStatusCheckerTest.java
@@ -1,0 +1,179 @@
+/*
+ *  Copyright (c) 2023 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LCC - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.connector.provision.gcp;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.storage.Blob;
+import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.connector.transfer.spi.types.ProvisionedResource;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.gcp.storage.GcsStoreSchema;
+import org.eclipse.edc.gcp.storage.StorageService;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GcsProvisionerStatusCheckerTest {
+
+    private GcsProvisionerStatusChecker statusChecker;
+    private StorageService storageServiceMock;
+
+    class ListPage implements Page<Blob> {
+        private List<Blob> blobs;
+
+        ListPage(List<Blob> blobs) {
+            this.blobs = blobs;
+        }
+
+        public boolean hasNextPage() {
+            return false;
+        }
+
+        public String getNextPageToken() {
+            return "";
+        }
+
+        public Page<Blob> getNextPage() {
+            return null;
+        }
+
+        public Iterable<Blob> iterateAll() {
+            return blobs;
+        }
+
+        public Iterable<Blob> getValues() {
+            return null;
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        storageServiceMock = mock(StorageService.class);
+        statusChecker = new GcsProvisionerStatusChecker(storageServiceMock);
+    }
+
+    private List<ProvisionedResource> createResourceList(List<String> bucketNames) {
+        List<ProvisionedResource> resources = new ArrayList<>();
+        for (var bucketName : bucketNames) {
+            GcsProvisionedResource resource = GcsProvisionedResource.Builder.newInstance()
+                    .bucketName(bucketName)
+                    .id("test_id")
+                    .transferProcessId("test_transfer_process_id")
+                    .resourceDefinitionId("test_resource_definition_id")
+                    .resourceName("test_resource_name")
+                    .dataAddress(DataAddress.Builder.newInstance().type(GcsStoreSchema.TYPE).build())
+                    .build();
+            resources.add(resource);
+        }
+        return resources;
+    }
+
+    private TransferProcess createTransferProcess(String bucketName) {
+        TransferProcess transferProcess = TransferProcess.Builder.newInstance()
+                .dataRequest(DataRequest.Builder.newInstance()
+                        .dataDestination(DataAddress.Builder.newInstance()
+                                .type(GcsStoreSchema.TYPE)
+                                .property(GcsStoreSchema.BUCKET_NAME, bucketName).build())
+                        .build()
+                ).build();
+        return transferProcess;
+    }
+
+    private String getValidTransferCompleteBlobName(String bucketName) {
+        return bucketName + ".complete";
+    }
+
+    private String getInvalidTransferCompleteBlobName(String bucketName) {
+        return bucketName + ".invalidcomplete";
+    }
+
+    private List<Blob> createValidBlobList(String bucketName) {
+        List<Blob> blobs = new ArrayList<>();
+        Blob blob = mock(Blob.class);
+        when(blob.getName()).thenReturn(getValidTransferCompleteBlobName(bucketName));
+        blobs.add(blob);
+        return blobs;
+    }
+
+    private List<Blob> createInvalidBlobList(String bucketName) {
+        List<Blob> blobs = new ArrayList<>();
+        Blob blob = mock(Blob.class);
+        when(blob.getName()).thenReturn(getInvalidTransferCompleteBlobName(bucketName));
+        blobs.add(blob);
+        return blobs;
+    }
+
+    private void setupValidStorageService(List<String> bucketNames) {
+        for (var bucketName : bucketNames) {
+            List<Blob> blobs = createValidBlobList(bucketName);
+            when(storageServiceMock.list(bucketName)).thenReturn(new ListPage(blobs));
+        }
+    }
+
+    private void setupInvalidStorageService(List<String> bucketNames) {
+        for (var bucketName : bucketNames) {
+            List<Blob> blobs = createInvalidBlobList(bucketName);
+            when(storageServiceMock.list(bucketName)).thenReturn(new ListPage(blobs));
+        }
+    }
+
+    @Test
+    void transferCompleteWithoutResourcesTest() {
+        List<String> bucketNames = Arrays.asList("test_bucket");
+
+        TransferProcess transferProcess = createTransferProcess(bucketNames.get(0));
+        setupValidStorageService(bucketNames);
+        assertThat(statusChecker.isComplete(transferProcess, null)).isTrue();
+    }
+
+    @Test
+    void transferCompleteWithResourcesTest() {
+        List<String> bucketNames = Arrays.asList("test_bucket");
+
+        TransferProcess transferProcess = createTransferProcess(bucketNames.get(0));
+        setupValidStorageService(bucketNames);
+        List<ProvisionedResource> resources = createResourceList(bucketNames);
+
+        assertThat(statusChecker.isComplete(transferProcess, resources)).isTrue();
+    }
+
+    @Test
+    void transferNotCompleteWithoutResourcesTest() {
+        List<String> bucketNames = Arrays.asList("test_bucket");
+
+        TransferProcess transferProcess = createTransferProcess(bucketNames.get(0));
+        setupInvalidStorageService(bucketNames);
+        assertThat(statusChecker.isComplete(transferProcess, null)).isFalse();
+    }
+
+    @Test
+    void transferNotCompleteWithResourcesTest() {
+        List<String> bucketNames = Arrays.asList("test_bucket");
+
+        TransferProcess transferProcess = createTransferProcess(bucketNames.get(0));
+        setupInvalidStorageService(bucketNames);
+        List<ProvisionedResource> resources = createResourceList(bucketNames);
+
+        assertThat(statusChecker.isComplete(transferProcess, resources)).isFalse();
+    }
+}


### PR DESCRIPTION
- GCS transfer now moves to COMPLETED status
- GCS sink provides complete() method implementation
- GCS provision extension registers the status checker for GCS transfers

## What this PR changes/adds

GCS transfer status checker added and registered by provisioner.

## Why it does that

Without status checker, transfer process doesn't move to COMPLETED, resulting in a leak.

## Linked Issue(s)

Closes #41 
