### PR TITLE
fix: compilation errors, typo in GCS provisioner, IAM client delete account

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -118,7 +118,7 @@ maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.0, EPL-2.0 OR B
 maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
 maven/mavencentral/jakarta.inject/jakarta.inject-api/2.0.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.0, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7697
-maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, ee4j.validation
 maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.rest
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/javax.annotation/javax.annotation-api/1.3.2, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ16910
@@ -130,7 +130,7 @@ maven/mavencentral/net.bytebuddy/byte-buddy/1.14.1, Apache-2.0 AND BSD-3-Clause,
 maven/mavencentral/net.java.dev.jna/jna/5.12.1, Apache-2.0 OR LGPL-2.1-or-later, approved, #3217
 maven/mavencentral/net.sf.saxon/Saxon-HE/10.6, MPL-2.0 AND W3C, approved, #7945
 maven/mavencentral/org.antlr/antlr4-runtime/4.9.3, BSD-3-Clause, approved, #322
-maven/mavencentral/org.apache.commons/commons-compress/1.23.0, Apache-2.0 AND BSD-3-Clause, approved, #7506
+maven/mavencentral/org.apache.commons/commons-compress/1.24.0, Apache-2.0 AND BSD-3-Clause AND bzip2-1.0.6 AND LicenseRef-Public-Domain, approved, #10368
 maven/mavencentral/org.apache.httpcomponents/httpclient/4.5.14, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ23527
 maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.16, Apache-2.0, approved, CQ23528
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
@@ -260,7 +260,6 @@ maven/mavencentral/org.slf4j/slf4j-api/1.7.25, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.30, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.36, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/2.0.5, MIT, approved, #5915
-maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
-maven/mavencentral/org.testcontainers/junit-jupiter/1.19.0, MIT, approved, #10344
-maven/mavencentral/org.testcontainers/testcontainers/1.19.0, Apache-2.0 AND MIT, approved, #10347
+maven/mavencentral/org.testcontainers/junit-jupiter/1.19.1, MIT, approved, #10344
+maven/mavencentral/org.testcontainers/testcontainers/1.19.1, Apache-2.0 AND MIT, approved, #10347
 maven/mavencentral/org.threeten/threetenbp/1.6.8, BSD-3-Clause, approved, #6750

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
@@ -116,7 +116,7 @@ public class IamServiceImpl implements IamService {
     @Override
     public void deleteServiceAccountIfExists(GcpServiceAccount serviceAccount) {
         try (var client = iamClientSupplier.get()) {
-            ServiceAccountName serviceAccountName = ServiceAccountName.of(gcpProjectId, serviceAccount.getEmail());
+            var serviceAccountName = ServiceAccountName.of(gcpProjectId, serviceAccount.getEmail());
             client.deleteServiceAccount(serviceAccountName.toString());
             monitor.debug("Deleted service account: " + serviceAccount.getEmail());
         } catch (ApiException e) {

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
@@ -116,7 +116,8 @@ public class IamServiceImpl implements IamService {
     @Override
     public void deleteServiceAccountIfExists(GcpServiceAccount serviceAccount) {
         try (var client = iamClientSupplier.get()) {
-            client.deleteServiceAccount(serviceAccount.getName());
+            ServiceAccountName serviceAccountName = ServiceAccountName.of(gcpProjectId, serviceAccount.getEmail());
+            client.deleteServiceAccount(serviceAccountName.toString());
             monitor.debug("Deleted service account: " + serviceAccount.getEmail());
         } catch (ApiException e) {
             if (e.getStatusCode().getCode() == StatusCode.Code.NOT_FOUND) {

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisioner.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisioner.java
@@ -135,7 +135,7 @@ public class GcsProvisioner implements Provisioner<GcsResourceDefinition, GcsPro
         String serviceAccountName = null;
         if (serviceAccount != null) {
             serviceAccountEmail = serviceAccount.getEmail();
-            serviceAccountName = serviceAccount.getEmail();
+            serviceAccountName = serviceAccount.getName();
         }
         return GcsProvisionedResource.Builder.newInstance()
                 .id(resourceDefinition.getId())

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@
  *
  */
 
-rootProject.name = "technology-gcp"
+rootProject.name = "Technology-Gcp"
 
 // this is needed to have access to snapshot builds of plugins
 pluginManagement {


### PR DESCRIPTION
## What this PR changes/adds

- with 0.3.2 pipeline.DataSource needs to implement AutoCloseable, added close method to GCS data source
- typo in GCS provisioner copying email address onto service account name
- improved deleteServiceAccountIfExists method of IamServiceImpl following https://cloud.google.com/java/docs/reference/google-iam-admin/1.2.3/com.google.cloud.iam.admin.v1.IAMClient#com_google_cloud_iam_admin_v1_IAMClient_deleteServiceAccount_java_lang_String_
- changed rootProject.name to be case sensitive to avoid "IllegalStateException: Module entity with name: Technology-Gcp.extensions.test should be available" while gradle sync

## Why it does that

Fixes deprovisioning of service accounts, and enable compilation with Connector 0.3.2

## Linked Issue(s)

Closes #54 
