### PR TITLE
 feat(dataplane_gcs_enhancement): Enhancing Google Dataplane to allow…

### DIFF
--- a/extensions/data-plane/data-plane-google-storage/README.md
+++ b/extensions/data-plane/data-plane-google-storage/README.md
@@ -5,26 +5,35 @@
 This module contains a Data Plane extension to copy data to and from Google cloud storage.
 
 ### Authentication
+Google storage data plane supports three different approaches for authentication:
+* Default authentication:
+    * Authenticates against the Google Cloud API using the [Application Default Credentials](https://cloud.google.com/docs/authentication#adc).
+    * These will automatically be provided if the connector is deployed with the correct service account attached.
+* Service Account key file
+    * Authentication using a Service Account key file exported from Google Cloud Platform
+    * Service Account key file can be stored in a vault or encoded as base64 and provided in the dataAddress.
 
-Currently, Google storage data plane only authenticates against the Google Cloud API using
-the [Application Default Credentials](https://cloud.google.com/docs/authentication#adc).
-
-These will automatically be provided if the connector is deployed with the correct service account attached.
 
 ### Data source properties
 
-| Key               | Description                                                               | Mandatory |
-|:------------------|:--------------------------------------------------------------------------|---|
-| type | GoogleCloudStorage                                                        | X |
-| bucket_name | A valid name of your bucket                                               | X |
-| blob_name | Name of your blob/object in the bucket. Currently only a single blob name | X |
+| Key                      | Description                                                                                                                                                                                                                                                                                                                                                            | Mandatory |
+|:-------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---|
+| type                     | GoogleCloudStorage                                                                                                                                                                                                                                                                                                                                                     | X |
+| bucket_name              | A valid name of your bucket                                                                                                                                                                                                                                                                                                                                            | X |
+| blob_name                | Name of your blob/object in the bucket. Currently only a single blob name                                                                                                                                                                                                                                                                                              | X |
+| service_account_key_name | It should reference a vault entry containing a [Service Account Key File](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating) in json.            |  |
+| service_account_value    | It should contain a [Service Account Key File](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating) in json encoded with base64                    |  |
 
-### Data destination properties
+### Data destination properties without Google provisioner
 
-| Key               | Description                                                                                                | Mandatory with provisioner | Mandatory without provisioner |
-|:------------------|:-----------------------------------------------------------------------------------------------------------|----------------------------|---------------------------|
-| type | GoogleCloudStorage                                                                                         | X                          | X                         |
-| bucket_name | A valid name of your bucket                                                                                |                           | X                         |
-| blob_name | Name of your blob/object in the bucket. The source blob name will be used if it is not provided!           |                           |                           |
-| storage_class | STANDARD/ NEARLINE/ COLDLINE/ ARCHIVE / [More info](https://cloud.google.com/storage/docs/storage-classes) | X                          |                           |
-| location | [Available regions](https://cloud.google.com/storage/docs/locations#location-r)                            | X                          |                           |
+| Key               | Description                                                                                                    | Mandatory with provisioner | Mandatory without provisioner |
+|:------------------|:---------------------------------------------------------------------------------------------------------------|----------------------------|---------------------------|
+| type | GoogleCloudStorage                                                                                             | X                          | X                         |
+| bucket_name | A valid name of your bucket                                                                                    |                           | X                         |
+| blob_name | Name of your blob/object in the bucket. The source blob name will be used if it is not provided!               |                           |                           |
+| storage_class | STANDARD/ NEARLINE/ COLDLINE/ ARCHIVE / [More info](https://cloud.google.com/storage/docs/storage-classes)     | X                          |                           |
+| location | [Available regions](https://cloud.google.com/storage/docs/locations#location-r)                                | X                          |                           |
+| service_account_key_name | It should reference a vault entry containing a [Service Account Key File](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating) in json.            |  |
+| service_account_value    | It should contain a [Service Account Key File](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating) in json encoded with base64                    |  |
+
+### [Data destination properties with Google provisioner](../../control-plane/provision/provision-gcs/README.md)

--- a/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/DataPlaneGcsExtension.java
+++ b/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/DataPlaneGcsExtension.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.dataplane.gcp.storage;
 
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataTransferExecutorServiceContainer;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
+import org.eclipse.edc.gcp.common.GcpCredentials;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.security.Vault;
@@ -49,11 +50,12 @@ public class DataPlaneGcsExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
 
         var monitor = context.getMonitor();
+        var gcpCredential = new GcpCredentials(vault, typeManager, monitor);
 
-        var sourceFactory = new GcsDataSourceFactory(monitor);
+        var sourceFactory = new GcsDataSourceFactory(monitor, gcpCredential);
         pipelineService.registerFactory(sourceFactory);
 
-        var sinkFactory = new GcsDataSinkFactory(executorContainer.getExecutorService(), monitor, vault, typeManager);
+        var sinkFactory = new GcsDataSinkFactory(executorContainer.getExecutorService(), monitor, vault, typeManager, gcpCredential);
         pipelineService.registerFactory(sinkFactory);
     }
 }

--- a/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSinkFactory.java
@@ -15,15 +15,12 @@
 package org.eclipse.edc.connector.dataplane.gcp.storage;
 
 
-import com.google.auth.oauth2.AccessToken;
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import org.eclipse.edc.connector.dataplane.gcp.storage.validation.GcsSinkDataAddressValidator;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSink;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSinkFactory;
-import org.eclipse.edc.gcp.common.GcpAccessToken;
-import org.eclipse.edc.gcp.common.GcpException;
+import org.eclipse.edc.gcp.common.GcpCredentials;
+import org.eclipse.edc.gcp.common.GcpServiceAccountCredentials;
 import org.eclipse.edc.gcp.storage.GcsStoreSchema;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
@@ -35,8 +32,6 @@ import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
 import org.eclipse.edc.validator.spi.Validator;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.IOException;
-import java.util.Date;
 import java.util.concurrent.ExecutorService;
 
 public class GcsDataSinkFactory implements DataSinkFactory {
@@ -47,12 +42,14 @@ public class GcsDataSinkFactory implements DataSinkFactory {
     private final Vault vault;
     private final TypeManager typeManager;
 
+    private final GcpCredentials gcpCredential;
 
-    public GcsDataSinkFactory(ExecutorService executorService, Monitor monitor, Vault vault, TypeManager typeManager) {
+    public GcsDataSinkFactory(ExecutorService executorService, Monitor monitor, Vault vault, TypeManager typeManager, GcpCredentials gcpCredential) {
         this.executorService = executorService;
         this.monitor = monitor;
         this.vault = vault;
         this.typeManager = typeManager;
+        this.gcpCredential = gcpCredential;
     }
 
     @Override
@@ -74,9 +71,14 @@ public class GcsDataSinkFactory implements DataSinkFactory {
         }
 
         var destination = request.getDestinationDataAddress();
-
-        var storageClient = createStorageClient(destination.getKeyName());
-
+        var tokenKeyName = destination.getKeyName();
+        var serviceAccountKeyName = destination.getStringProperty(GcsStoreSchema.SERVICE_ACCOUNT_KEY_NAME);
+        var serviceAccountValue = destination.getStringProperty(GcsStoreSchema.SERVICE_ACCOUNT_KEY_VALUE);
+        var gcpServiceAccountCredentials = new GcpServiceAccountCredentials(tokenKeyName, serviceAccountKeyName, serviceAccountValue);
+        var googleCredentials = gcpCredential.resolveGoogleCredentialsFromDataAddress(gcpServiceAccountCredentials);
+        var storageClient = StorageOptions.newBuilder()
+                .setCredentials(googleCredentials)
+                .build().getService();
         return GcsDataSink.Builder.newInstance()
                 .storageClient(storageClient)
                 .bucketName(destination.getStringProperty(GcsStoreSchema.BUCKET_NAME))
@@ -87,26 +89,4 @@ public class GcsDataSinkFactory implements DataSinkFactory {
                 .build();
     }
 
-    private Storage createStorageClient(String keyName) {
-        GoogleCredentials googleCredentials;
-        //Get credential from the token if it exists in the vault otherwise use the default credentials of the system.
-        if (keyName != null && !keyName.isEmpty()) {
-            var credentialsContent = vault.resolveSecret(keyName);
-            var gcsAccessToken = typeManager.readValue(credentialsContent, GcpAccessToken.class);
-            googleCredentials = GoogleCredentials.create(
-                    new AccessToken(gcsAccessToken.getToken(),
-                            new Date(gcsAccessToken.getExpiration()))
-            );
-        } else {
-            try {
-                googleCredentials = GoogleCredentials.getApplicationDefault();
-            } catch (IOException e) {
-                throw new GcpException("Error while getting the default credentials.", e);
-            }
-        }
-
-        return StorageOptions.newBuilder()
-                .setCredentials(googleCredentials)
-                .build().getService();
-    }
 }

--- a/extensions/data-plane/data-plane-google-storage/src/test/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-google-storage/src/test/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSinkFactoryTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.dataplane.gcp.storage;
 
+import org.eclipse.edc.gcp.common.GcpCredentials;
 import org.eclipse.edc.gcp.storage.GcsStoreSchema;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.security.Vault;
@@ -40,8 +41,8 @@ class GcsDataSinkFactoryTest {
             mock(ExecutorService.class),
             mock(Monitor.class),
             mock(Vault.class),
-            new TypeManager()
-    );
+            new TypeManager(),
+            mock(GcpCredentials.class));
 
     @Test
     void canHandle_returnsTrueWhenExpectedType() {

--- a/extensions/data-plane/data-plane-google-storage/src/test/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-google-storage/src/test/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSourceFactoryTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.dataplane.gcp.storage;
 
+import org.eclipse.edc.gcp.common.GcpCredentials;
 import org.eclipse.edc.gcp.storage.GcsStoreSchema;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ class GcsDataSourceFactoryTest {
     Monitor monitor = mock(Monitor.class);
 
     private final GcsDataSourceFactory factory =
-            new GcsDataSourceFactory(monitor);
+            new GcsDataSourceFactory(monitor, mock(GcpCredentials.class));
 
     @Test
     void canHandle_returnsTrueWhenExpectedType() {


### PR DESCRIPTION

## What this PR changes/adds
We implemented other approaches for authentication against the gcp api in the [core](https://github.com/eclipse-edc/Technology-Gcp/pull/60) already. Now, in this PR, this feature is being used by the dataplane to enhance the usage of google storage data-plane. Therefore, users can dynamically change their service account key file in run time by adding it into the vault and or adding it into the data address.

## Further notes

Another approach for authentication is to create a [Service Account key file](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) and use it to retrieve the GoogleCredentials. Similar to Azure storage Data Plane, the key could be uploaded into the vault and be pointed in the keyname in the DataAddress.

## Linked Issue(s)

Closes #59 
