### PR TITLE
feat: GCS provisioner using ADC or existing service account for access tokens

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -28,6 +28,7 @@ maven/mavencentral/com.google.api/api-common/2.21.0, BSD-3-Clause, approved, cle
 maven/mavencentral/com.google.api/gax-grpc/2.38.0, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.google.api/gax-httpjson/2.38.0, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.google.api/gax/2.38.0, BSD-3-Clause, approved, #12035
+maven/mavencentral/com.google.apis/google-api-services-iam/v2-rev20240108-2.0.0, , restricted, clearlydefined
 maven/mavencentral/com.google.apis/google-api-services-storage/v1-rev20231117-2.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.auth/google-auth-library-credentials/1.20.0, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.google.auth/google-auth-library-oauth2-http/1.20.0, BSD-3-Clause, approved, clearlydefined
@@ -52,14 +53,21 @@ maven/mavencentral/com.google.guava/failureaccess/1.0.1, Apache-2.0, approved, C
 maven/mavencentral/com.google.guava/guava/29.0-android, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/guava/30.1.1-android, Apache-2.0 AND CC0-1.0 AND LicenseRef-Public-Domain, approved, CQ23244
 maven/mavencentral/com.google.guava/guava/31.0.1-jre, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.guava/guava/31.1-android, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.guava/guava/31.1-jre, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/guava/32.0.0-android, Apache-2.0 AND CC0-1.0 AND CC-PDDC, approved, #8772
 maven/mavencentral/com.google.guava/guava/32.0.1-jre, Apache-2.0 AND CC0-1.0 AND CC-PDDC, approved, #8772
 maven/mavencentral/com.google.guava/guava/32.1.3-jre, Apache-2.0 AND CC0-1.0 AND LicenseRef-Public-Domain, approved, #9229
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
+maven/mavencentral/com.google.http-client/google-http-client-apache-v2/1.42.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.http-client/google-http-client-apache-v2/1.43.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.http-client/google-http-client-appengine/1.43.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.http-client/google-http-client-gson/1.42.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.http-client/google-http-client-gson/1.42.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.http-client/google-http-client-gson/1.43.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.http-client/google-http-client-jackson2/1.43.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.http-client/google-http-client/1.42.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.http-client/google-http-client/1.42.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.http-client/google-http-client/1.43.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.j2objc/j2objc-annotations/1.3, Apache-2.0, approved, CQ21195
 maven/mavencentral/com.google.j2objc/j2objc-annotations/2.8, Apache-2.0, approved, clearlydefined
@@ -77,6 +85,7 @@ maven/mavencentral/com.squareup.okio/okio-jvm/3.6.0, Apache-2.0, approved, #1115
 maven/mavencentral/com.squareup.okio/okio/3.6.0, Apache-2.0, approved, #11155
 maven/mavencentral/commons-beanutils/commons-beanutils/1.9.4, Apache-2.0, approved, CQ12654
 maven/mavencentral/commons-codec/commons-codec/1.11, Apache-2.0 AND BSD-3-Clause, approved, CQ15971
+maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause AND LicenseRef-Public-Domain, approved, CQ22641
 maven/mavencentral/commons-codec/commons-codec/1.16.0, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9157
 maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, CQ10385
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -117,9 +117,7 @@ maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0, EPL-2.0 OR GPL-2.0-onl
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/javax.annotation/javax.annotation-api/1.3.2, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ16910
 maven/mavencentral/junit/junit/4.13.2, EPL-2.0, approved, CQ23636
-maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.10, Apache-2.0, approved, #7164
-maven/mavencentral/net.bytebuddy/byte-buddy/1.12.21, Apache-2.0 AND BSD-3-Clause, approved, #1811
-maven/mavencentral/net.bytebuddy/byte-buddy/1.14.10, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.11, Apache-2.0, approved, #7164
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.11, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #6709
 maven/mavencentral/net.sf.saxon/Saxon-HE/10.6, MPL-2.0 AND W3C, approved, #7945
@@ -128,7 +126,6 @@ maven/mavencentral/org.apache.commons/commons-compress/1.24.0, Apache-2.0 AND BS
 maven/mavencentral/org.apache.httpcomponents/httpclient/4.5.14, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ23527
 maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.16, Apache-2.0, approved, CQ23528
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.assertj/assertj-core/3.24.2, Apache-2.0, approved, #6161
 maven/mavencentral/org.assertj/assertj-core/3.25.1, Apache-2.0, approved, #12585
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.77, MIT, approved, #11593
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.77, MIT AND CC0-1.0, approved, #11595
@@ -232,7 +229,7 @@ maven/mavencentral/org.junit/junit-bom/5.10.1, EPL-2.0, approved, #9844
 maven/mavencentral/org.junit/junit-bom/5.9.2, EPL-2.0, approved, #4711
 maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.15, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ21484
 maven/mavencentral/org.mockito/mockito-core/5.2.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #7401
-maven/mavencentral/org.mockito/mockito-core/5.8.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #11787
+maven/mavencentral/org.mockito/mockito-core/5.9.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #12774
 maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.opentest4j/opentest4j/1.3.0, Apache-2.0, approved, #9713
 maven/mavencentral/org.ow2.asm/asm-commons/9.5, BSD-3-Clause, approved, #7553

--- a/extensions/common/gcp/gcp-core/build.gradle.kts
+++ b/extensions/common/gcp/gcp-core/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(libs.googlecloud.iam.admin)
     implementation(libs.googlecloud.storage)
     implementation(libs.googlecloud.iam.credentials)
+    implementation(libs.googleapis.iam)
     testImplementation(libs.edc.junit)
 }
 

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpConfiguration.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpConfiguration.java
@@ -41,9 +41,9 @@ public class GcpConfiguration {
 
     public GcpConfiguration(ServiceExtensionContext context) {
         projectId = context.getSetting(PROJECT_ID, ServiceOptions.getDefaultProjectId());
-        serviceAccountName = context.getSetting(SACCOUNT_NAME, "");
-        serviceAccountFile = context.getSetting(SACCOUNT_FILE, "");
-        universeDomain = context.getSetting(UNIVERSE_DOMAIN, "");
+        serviceAccountName = context.getSetting(SACCOUNT_NAME, null);
+        serviceAccountFile = context.getSetting(SACCOUNT_FILE, null);
+        universeDomain = context.getSetting(UNIVERSE_DOMAIN, null);
     }
 
     /**

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/AccessTokenProvider.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/AccessTokenProvider.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LCC - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.gcp.iam;
+
+import org.eclipse.edc.gcp.common.GcpAccessToken;
+
+/**
+ * Interface for credentials providing access tokens.
+ */
+public interface AccessTokenProvider {
+    /**
+     * Returns the access token generated for the credentials.
+     *
+     * @return the {@link GcpAccessToken} for the credentials, null if error occurs.
+     */
+    GcpAccessToken getAccessToken();
+}

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamService.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamService.java
@@ -32,12 +32,27 @@ public interface IamService {
     GcpServiceAccount getOrCreateServiceAccount(String serviceAccountName, String serviceAccountDescription);
 
     /**
+     * Returns the existing service account with the matching name.
+     *
+     * @param serviceAccountName        the name for the service account. Limited to 30 chars
+     * @return the {@link GcpServiceAccount} describing the service account
+     */
+    GcpServiceAccount getServiceAccount(String serviceAccountName);
+
+    /**
      * Creates a temporary valid OAunth2.0 access token for the service account
      *
      * @param serviceAccount The service account the token should be created for
      * @return {@link GcpAccessToken}
      */
     GcpAccessToken createAccessToken(GcpServiceAccount serviceAccount);
+
+    /**
+     * Creates a temporary valid OAunth2.0 access token using the application default account credentials.
+     *
+     * @return {@link GcpAccessToken}
+     */
+    GcpAccessToken createDefaultAccessToken();
 
     /**
      * Delete the specified service account if it exists.

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamService.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamService.java
@@ -23,15 +23,6 @@ import org.eclipse.edc.gcp.common.GcpServiceAccount;
  */
 public interface IamService {
     /**
-     * Creates or returns the service account with the matching name and description.
-     *
-     * @param serviceAccountName        the name for the service account. Limited to 30 chars
-     * @param serviceAccountDescription the unique description for the service account that is used to avoid reuse of service accounts
-     * @return the {@link GcpServiceAccount} describing the service account
-     */
-    GcpServiceAccount getOrCreateServiceAccount(String serviceAccountName, String serviceAccountDescription);
-
-    /**
      * Returns the existing service account with the matching name.
      *
      * @param serviceAccountName        the name for the service account. Limited to 30 chars
@@ -53,12 +44,4 @@ public interface IamService {
      * @return {@link GcpAccessToken}
      */
     GcpAccessToken createDefaultAccessToken();
-
-    /**
-     * Delete the specified service account if it exists.
-     * Do nothing in case it doesn't exist (anymore)
-     *
-     * @param serviceAccount The service account that should be deleted
-     */
-    void deleteServiceAccountIfExists(GcpServiceAccount serviceAccount);
 }

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
@@ -230,6 +230,7 @@ public class IamServiceImpl implements IamService {
             this.monitor = monitor;
         }
 
+        @Override
         public GcpAccessToken getAccessToken() {
             try {
                 var credentials = GoogleCredentials.getApplicationDefault();

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
@@ -44,19 +44,19 @@ public class IamServiceImpl implements IamService {
     private final Supplier<IAMClient> iamClientSupplier;
     private final Supplier<IamCredentialsClient> iamCredentialsClientSupplier;
     private final Monitor monitor;
-    private final Supplier<ApplicationDefaultCredentials> adc;
+    private final Supplier<ApplicationDefaultCredentials> applicationDefaultCredentials;
 
     private IamServiceImpl(Monitor monitor,
                         String gcpProjectId,
                         Supplier<IAMClient> iamClientSupplier,
                         Supplier<IamCredentialsClient> iamCredentialsClientSupplier,
-                        Supplier<ApplicationDefaultCredentials> adc
+                        Supplier<ApplicationDefaultCredentials> applicationDefaultCredentials
     ) {
         this.monitor = monitor;
         this.gcpProjectId = gcpProjectId;
         this.iamClientSupplier = iamClientSupplier;
         this.iamCredentialsClientSupplier = iamCredentialsClientSupplier;
-        this.adc = adc;
+        this.applicationDefaultCredentials = applicationDefaultCredentials;
     }
 
     private IamServiceImpl(Monitor monitor,
@@ -145,7 +145,7 @@ public class IamServiceImpl implements IamService {
 
     @Override
     public GcpAccessToken createDefaultAccessToken() {
-        return adc.get().getAccessToken();
+        return applicationDefaultCredentials.get().getAccessToken();
     }
 
     @Override
@@ -173,7 +173,7 @@ public class IamServiceImpl implements IamService {
         private final Monitor monitor;
         private Supplier<IAMClient> iamClientSupplier;
         private Supplier<IamCredentialsClient> iamCredentialsClientSupplier;
-        private Supplier<IamServiceImpl.ApplicationDefaultCredentials> adc;
+        private Supplier<IamServiceImpl.ApplicationDefaultCredentials> applicationDefaultCredentials;
 
         private Builder(Monitor monitor, String gcpProjectId) {
             this.gcpProjectId = gcpProjectId;
@@ -194,8 +194,8 @@ public class IamServiceImpl implements IamService {
             return this;
         }
 
-        public Builder adc(Supplier<IamServiceImpl.ApplicationDefaultCredentials> adc) {
-            this.adc = adc;
+        public Builder applicationDefaultCredentials(Supplier<IamServiceImpl.ApplicationDefaultCredentials> applicationDefaultCredentials) {
+            this.applicationDefaultCredentials = applicationDefaultCredentials;
             return this;
         }
 
@@ -209,9 +209,9 @@ public class IamServiceImpl implements IamService {
                 iamCredentialsClientSupplier = defaultIamCredentialsClientSupplier();
             }
 
-            if (adc != null) {
+            if (applicationDefaultCredentials != null) {
                 return new IamServiceImpl(monitor, gcpProjectId, iamClientSupplier,
-                    iamCredentialsClientSupplier, adc);
+                    iamCredentialsClientSupplier, applicationDefaultCredentials);
             }
 
             return new IamServiceImpl(monitor, gcpProjectId, iamClientSupplier, iamCredentialsClientSupplier);

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.gcp.iam;
 
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.StatusCode;
-import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.iam.admin.v1.IAMClient;
 import com.google.cloud.iam.credentials.v1.GenerateAccessTokenRequest;
@@ -254,9 +253,9 @@ public class IamServiceImpl implements IamService {
 
         public GcpAccessToken getAccessToken() {
             try {
-                GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
+                var credentials = GoogleCredentials.getApplicationDefault();
                 credentials.refreshIfExpired();
-                AccessToken token = credentials.getAccessToken();
+                var token = credentials.getAccessToken();
                 return new GcpAccessToken(token.getTokenValue(), token.getExpirationTime().getTime());
             } catch (IOException ioException) {
                 monitor.severe("Cannot get application default access token", ioException);

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
@@ -223,13 +223,7 @@ public class IamServiceImpl implements IamService {
         }
     }
 
-    static class ApplicationDefaultCredentials implements AccessTokenProvider {
-        private final Monitor monitor;
-
-        ApplicationDefaultCredentials(Monitor monitor) {
-            this.monitor = monitor;
-        }
-
+    private record ApplicationDefaultCredentials(Monitor monitor) implements AccessTokenProvider {
         @Override
         public GcpAccessToken getAccessToken() {
             try {

--- a/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/iam/IamServiceImplTest.java
+++ b/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/iam/IamServiceImplTest.java
@@ -54,7 +54,7 @@ class IamServiceImplTest {
     private IAMClient iamClient;
     private IamCredentialsClient iamCredentialsClient;
 
-    private IamServiceImpl.ApplicationDefaultCredentials adc;
+    private IamServiceImpl.ApplicationDefaultCredentials applicationDefaultCredentials;
     private GcpServiceAccount testServiceAccount;
     private final String iamServiceAccountName = "projects/" + projectId + "/serviceAccounts/" + serviceAccountEmail;
 
@@ -63,12 +63,12 @@ class IamServiceImplTest {
         var monitor = Mockito.mock(Monitor.class);
         iamClient = Mockito.mock(IAMClient.class);
         iamCredentialsClient = Mockito.mock(IamCredentialsClient.class);
-        adc = Mockito.mock(IamServiceImpl.ApplicationDefaultCredentials.class);
+        applicationDefaultCredentials = Mockito.mock(IamServiceImpl.ApplicationDefaultCredentials.class);
         testServiceAccount = new GcpServiceAccount(serviceAccountEmail, serviceAccountName, serviceAccountDescription);
         iamApi = IamServiceImpl.Builder.newInstance(monitor, projectId)
                 .iamClientSupplier(() -> iamClient)
                 .iamCredentialsClientSupplier(() -> iamCredentialsClient)
-                .adc(() -> adc)
+                .applicationDefaultCredentials(() -> applicationDefaultCredentials)
                 .build();
     }
 
@@ -153,7 +153,7 @@ class IamServiceImplTest {
     void testCreateDefaultAccessToken() {
         var expectedTokenString = "test-access-token";
         long timeout = 3600;
-        when(adc.getAccessToken()).thenReturn(new GcpAccessToken(expectedTokenString, timeout));
+        when(applicationDefaultCredentials.getAccessToken()).thenReturn(new GcpAccessToken(expectedTokenString, timeout));
 
         var accessToken = iamApi.createDefaultAccessToken();
         assertThat(accessToken.getToken()).isEqualTo(expectedTokenString);
@@ -162,7 +162,7 @@ class IamServiceImplTest {
 
     @Test
     void testCreateDefaultAccessTokenError() {
-        when(adc.getAccessToken()).thenReturn(null);
+        when(applicationDefaultCredentials.getAccessToken()).thenReturn(null);
 
         var accessToken = iamApi.createDefaultAccessToken();
         assertThat(accessToken).isNull();

--- a/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/iam/IamServiceImplTest.java
+++ b/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/iam/IamServiceImplTest.java
@@ -68,7 +68,7 @@ class IamServiceImplTest {
         iamApi = IamServiceImpl.Builder.newInstance(monitor, projectId)
                 .iamClientSupplier(() -> iamClient)
                 .iamCredentialsClientSupplier(() -> iamCredentialsClient)
-                .applicationDefaultCredentials(() -> applicationDefaultCredentials)
+                .applicationDefaultCredentials(applicationDefaultCredentials)
                 .build();
     }
 

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsConsumerResourceDefinitionGenerator.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsConsumerResourceDefinitionGenerator.java
@@ -35,9 +35,10 @@ public class GcsConsumerResourceDefinitionGenerator implements ConsumerResourceD
         var location = destination.getStringProperty(GcsStoreSchema.LOCATION);
         var storageClass = destination.getStringProperty(GcsStoreSchema.STORAGE_CLASS);
         var bucketName = destination.getStringProperty(GcsStoreSchema.BUCKET_NAME);
+        var serviceAccount = destination.getStringProperty(GcsStoreSchema.SERVICE_ACCOUNT_NAME);
 
         return GcsResourceDefinition.Builder.newInstance().id(id).location(location)
-                .storageClass(storageClass).bucketName(bucketName).build();
+                .storageClass(storageClass).bucketName(bucketName).serviceAccount(serviceAccount).build();
     }
 
     @Override

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsConsumerResourceDefinitionGenerator.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsConsumerResourceDefinitionGenerator.java
@@ -38,7 +38,7 @@ public class GcsConsumerResourceDefinitionGenerator implements ConsumerResourceD
         var serviceAccount = destination.getStringProperty(GcsStoreSchema.SERVICE_ACCOUNT_NAME);
 
         return GcsResourceDefinition.Builder.newInstance().id(id).location(location)
-                .storageClass(storageClass).bucketName(bucketName).serviceAccount(serviceAccount).build();
+                .storageClass(storageClass).bucketName(bucketName).serviceAccountName(serviceAccount).build();
     }
 
     @Override

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionExtension.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionExtension.java
@@ -50,7 +50,7 @@ public class GcsProvisionExtension implements ServiceExtension {
         var storageClient = createDefaultStorageClient(gcpConfiguration.getProjectId());
         var storageService = new StorageServiceImpl(storageClient, monitor);
 
-        var provisioner = new GcsProvisioner(monitor, storageService, iamService);
+        var provisioner = new GcsProvisioner(gcpConfiguration, monitor, storageService, iamService);
         provisionManager.register(provisioner);
 
         manifestGenerator.registerGenerator(new GcsConsumerResourceDefinitionGenerator());

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsResourceDefinition.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsResourceDefinition.java
@@ -23,6 +23,7 @@ public class GcsResourceDefinition extends ResourceDefinition {
     private String location;
     private String storageClass;
     private String bucketName;
+    private String serviceAccount;
 
     private GcsResourceDefinition() {
     }
@@ -39,12 +40,17 @@ public class GcsResourceDefinition extends ResourceDefinition {
         return this.bucketName;
     }
 
+    public String getServiceAccount() {
+        return this.serviceAccount;
+    }
+
     @Override
     public Builder toBuilder() {
         return initializeBuilder(new Builder())
                 .location(location)
                 .storageClass(storageClass)
-                .bucketName(bucketName);
+                .bucketName(bucketName)
+                .serviceAccount(serviceAccount);
     }
 
     public static class Builder extends ResourceDefinition.Builder<GcsResourceDefinition, Builder> {
@@ -69,6 +75,11 @@ public class GcsResourceDefinition extends ResourceDefinition {
 
         public Builder bucketName(String bucketName) {
             resourceDefinition.bucketName = bucketName;
+            return this;
+        }
+
+        public Builder serviceAccount(String serviceAccount) {
+            resourceDefinition.serviceAccount = serviceAccount;
             return this;
         }
 

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsResourceDefinition.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsResourceDefinition.java
@@ -23,7 +23,7 @@ public class GcsResourceDefinition extends ResourceDefinition {
     private String location;
     private String storageClass;
     private String bucketName;
-    private String serviceAccount;
+    private String serviceAccountName;
 
     private GcsResourceDefinition() {
     }
@@ -40,8 +40,8 @@ public class GcsResourceDefinition extends ResourceDefinition {
         return this.bucketName;
     }
 
-    public String getServiceAccount() {
-        return this.serviceAccount;
+    public String getServiceAccountName() {
+        return this.serviceAccountName;
     }
 
     @Override
@@ -50,7 +50,7 @@ public class GcsResourceDefinition extends ResourceDefinition {
                 .location(location)
                 .storageClass(storageClass)
                 .bucketName(bucketName)
-                .serviceAccount(serviceAccount);
+                .serviceAccountName(serviceAccountName);
     }
 
     public static class Builder extends ResourceDefinition.Builder<GcsResourceDefinition, Builder> {
@@ -78,8 +78,8 @@ public class GcsResourceDefinition extends ResourceDefinition {
             return this;
         }
 
-        public Builder serviceAccount(String serviceAccount) {
-            resourceDefinition.serviceAccount = serviceAccount;
+        public Builder serviceAccountName(String serviceAccountName) {
+            resourceDefinition.serviceAccountName = serviceAccountName;
             return this;
         }
 

--- a/extensions/control-plane/provision/provision-gcs/src/test/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerTest.java
+++ b/extensions/control-plane/provision/provision-gcs/src/test/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.provision.gcp;
 
 import org.eclipse.edc.gcp.common.GcpAccessToken;
+import org.eclipse.edc.gcp.common.GcpConfiguration;
 import org.eclipse.edc.gcp.common.GcpException;
 import org.eclipse.edc.gcp.common.GcpServiceAccount;
 import org.eclipse.edc.gcp.common.GcsBucket;
@@ -44,13 +45,15 @@ class GcsProvisionerTest {
     private StorageService storageServiceMock;
     private IamService iamServiceMock;
     private Policy testPolicy;
+    private GcpConfiguration gcpConfiguration;
 
     @BeforeEach
     void setUp() {
         storageServiceMock = mock();
         iamServiceMock = mock();
+        gcpConfiguration = mock();
         testPolicy = Policy.Builder.newInstance().build();
-        provisioner = new GcsProvisioner(mock(Monitor.class), storageServiceMock, iamServiceMock);
+        provisioner = new GcsProvisioner(gcpConfiguration, mock(Monitor.class), storageServiceMock, iamServiceMock);
     }
 
     @Test
@@ -75,6 +78,8 @@ class GcsProvisionerTest {
         var bucket = new GcsBucket(bucketName);
         var serviceAccount = new GcpServiceAccount("test-sa", "sa-name", "description");
         var token = new GcpAccessToken("token", 123);
+
+        when(gcpConfiguration.getServiceAccountName()).thenReturn(null);
 
         when(storageServiceMock.getOrCreateBucket(bucketName, bucketLocation)).thenReturn(bucket);
         when(storageServiceMock.isEmpty(bucketName)).thenReturn(true);
@@ -111,6 +116,8 @@ class GcsProvisionerTest {
         var bucket = new GcsBucket(bucketName);
         var bucketLocation = resourceDefinition.getLocation();
 
+        when(gcpConfiguration.getServiceAccountName()).thenReturn(serviceAccount.getName());
+
         when(storageServiceMock.getOrCreateBucket(bucketName, bucketLocation)).thenReturn(bucket);
         when(storageServiceMock.isEmpty(bucketName)).thenReturn(true);
         when(iamServiceMock.getServiceAccount(serviceAccount.getName())).thenReturn(serviceAccount);
@@ -139,6 +146,7 @@ class GcsProvisionerTest {
         var bucketName = resourceDefinition.getId();
         var bucketLocation = resourceDefinition.getLocation();
 
+        when(gcpConfiguration.getServiceAccountName()).thenReturn(null);
         when(storageServiceMock.getOrCreateBucket(bucketName, bucketLocation)).thenReturn(new GcsBucket(bucketName));
         when(storageServiceMock.isEmpty(bucketName)).thenReturn(false);
 
@@ -207,11 +215,11 @@ class GcsProvisionerTest {
                 .transferProcessId(transferProcessId).build();
     }
 
-    private GcsResourceDefinition createResourceDefinition(String id, String location, String storageClass, String transferProcessId, String serviceAccount) {
+    private GcsResourceDefinition createResourceDefinition(String id, String location, String storageClass, String transferProcessId, String serviceAccountName) {
         return GcsResourceDefinition.Builder.newInstance().id(id)
             .location(location).storageClass(storageClass)
             .transferProcessId(transferProcessId)
-            .serviceAccount(serviceAccount)
+            .serviceAccountName(serviceAccountName)
             .build();
     }
 

--- a/extensions/control-plane/provision/provision-gcs/src/test/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerTest.java
+++ b/extensions/control-plane/provision/provision-gcs/src/test/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerTest.java
@@ -22,7 +22,6 @@ import org.eclipse.edc.gcp.iam.IamService;
 import org.eclipse.edc.gcp.storage.StorageService;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.response.ResponseStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
@@ -31,8 +30,6 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -50,8 +47,8 @@ class GcsProvisionerTest {
 
     @BeforeEach
     void setUp() {
-        storageServiceMock = mock(StorageService.class);
-        iamServiceMock = mock(IamService.class);
+        storageServiceMock = mock();
+        iamServiceMock = mock();
         testPolicy = Policy.Builder.newInstance().build();
         provisioner = new GcsProvisioner(mock(Monitor.class), storageServiceMock, iamServiceMock);
     }
@@ -81,9 +78,8 @@ class GcsProvisionerTest {
 
         when(storageServiceMock.getOrCreateBucket(bucketName, bucketLocation)).thenReturn(bucket);
         when(storageServiceMock.isEmpty(bucketName)).thenReturn(true);
-        when(iamServiceMock.getOrCreateServiceAccount(anyString(), anyString())).thenReturn(serviceAccount);
+        when(iamServiceMock.createDefaultAccessToken()).thenReturn(token);
         doNothing().when(storageServiceMock).addProviderPermissions(bucket, serviceAccount);
-        when(iamServiceMock.createAccessToken(serviceAccount)).thenReturn(token);
 
         var response = provisioner.provision(resourceDefinition, testPolicy).join().getContent();
 
@@ -98,8 +94,43 @@ class GcsProvisionerTest {
         });
 
         verify(storageServiceMock).getOrCreateBucket(bucketName, bucketLocation);
-        verify(storageServiceMock).addProviderPermissions(bucket, serviceAccount);
-        verify(iamServiceMock).createAccessToken(serviceAccount);
+        verify(iamServiceMock).createDefaultAccessToken();
+    }
+
+    @Test
+    void provisionWithImpersonationSuccess() {
+        var resourceDefinitionId = "id";
+        var location = "location";
+        var storageClass = "storage-class";
+        var serviceAccount = new GcpServiceAccount("test-sa", "sa-name", "description");
+        var token = new GcpAccessToken("token", 123);
+        var transferProcessId = UUID.randomUUID().toString();
+        var resourceDefinition = createResourceDefinition(resourceDefinitionId, location,
+                storageClass, transferProcessId, serviceAccount.getName());
+        var bucketName = resourceDefinition.getId();
+        var bucket = new GcsBucket(bucketName);
+        var bucketLocation = resourceDefinition.getLocation();
+
+        when(storageServiceMock.getOrCreateBucket(bucketName, bucketLocation)).thenReturn(bucket);
+        when(storageServiceMock.isEmpty(bucketName)).thenReturn(true);
+        when(iamServiceMock.getServiceAccount(serviceAccount.getName())).thenReturn(serviceAccount);
+        when(iamServiceMock.createAccessToken(serviceAccount)).thenReturn(token);
+        doNothing().when(storageServiceMock).addProviderPermissions(bucket, serviceAccount);
+
+        var response = provisioner.provision(resourceDefinition, testPolicy).join().getContent();
+
+        assertThat(response.getResource()).isInstanceOfSatisfying(GcsProvisionedResource.class, resource -> {
+            assertThat(resource.getId()).isEqualTo(resourceDefinitionId);
+            assertThat(resource.getTransferProcessId()).isEqualTo(transferProcessId);
+            assertThat(resource.getLocation()).isEqualTo(location);
+            assertThat(resource.getStorageClass()).isEqualTo(storageClass);
+        });
+        assertThat(response.getSecretToken()).isInstanceOfSatisfying(GcpAccessToken.class, secretToken -> {
+            assertThat(secretToken.getToken()).isEqualTo("token");
+        });
+
+        verify(storageServiceMock).getOrCreateBucket(bucketName, bucketLocation);
+        verify(iamServiceMock).createAccessToken(any());
     }
 
     @Test
@@ -116,8 +147,7 @@ class GcsProvisionerTest {
         assertThat(response.failed()).isFalse();
 
         verify(storageServiceMock).getOrCreateBucket(bucketName, bucketLocation);
-        verify(storageServiceMock, times(1)).addProviderPermissions(any(), any());
-        verify(iamServiceMock, times(1)).createAccessToken(any());
+        verify(iamServiceMock, times(1)).createDefaultAccessToken();
     }
 
     @Test
@@ -147,11 +177,9 @@ class GcsProvisionerTest {
         var description = "sa-description";
         var serviceAccount = new GcpServiceAccount(email, name, description);
 
-        doNothing().when(iamServiceMock).deleteServiceAccountIfExists(argThat(matches(serviceAccount)));
         var resource = createGcsProvisionedResource(email, name, id);
 
         var response = provisioner.deprovision(resource, testPolicy).join().getContent();
-        verify(iamServiceMock).deleteServiceAccountIfExists(argThat(matches(serviceAccount)));
         assertThat(response.getProvisionedResourceId()).isEqualTo(id);
     }
 
@@ -179,23 +207,12 @@ class GcsProvisionerTest {
                 .transferProcessId(transferProcessId).build();
     }
 
-    @Test
-    void deprovisionFails() {
-        var email = "test-email";
-        var name = "test-name";
-        var id = "test-id";
-        var description = "sa-description";
-        var serviceAccount = new GcpServiceAccount(email, name, description);
-        GcsProvisionedResource resource = createGcsProvisionedResource(email, name, id);
-
-        doThrow(new GcpException("some error"))
-                .when(iamServiceMock)
-                .deleteServiceAccountIfExists(argThat(matches(serviceAccount)));
-        var response = provisioner.deprovision(resource, testPolicy).join();
-
-        verify(iamServiceMock).deleteServiceAccountIfExists(argThat(matches(serviceAccount)));
-        assertThat(response.failed()).isTrue();
-        assertThat(response.getFailure().status()).isEqualTo(ResponseStatus.FATAL_ERROR);
+    private GcsResourceDefinition createResourceDefinition(String id, String location, String storageClass, String transferProcessId, String serviceAccount) {
+        return GcsResourceDefinition.Builder.newInstance().id(id)
+            .location(location).storageClass(storageClass)
+            .transferProcessId(transferProcessId)
+            .serviceAccount(serviceAccount)
+            .build();
     }
 
     private ArgumentMatcher<GcpServiceAccount> matches(GcpServiceAccount serviceAccount) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ googleCloudIamCredentials = "2.32.0"
 googleCloudStorage = "2.30.1"
 googleCloudSecretManager = "2.32.0"
 googleCloudCore = "2.28.0"
+googleApisIam = "v2-rev20240108-2.0.0"
 
 [libraries]
 assertj = { module = "org.assertj:assertj-core", version = "3.24.2" }
@@ -36,6 +37,7 @@ googlecloud-iam-admin = { module = "com.google.cloud:google-iam-admin", version.
 googlecloud-iam-credentials = { module = "com.google.cloud:google-cloud-iamcredentials", version.ref = "googleCloudIamCredentials" }
 googlecloud-secretmanager = { module = "com.google.cloud:google-cloud-secretmanager", version.ref = "googleCloudSecretManager" }
 googlecloud-storage = { module = "com.google.cloud:google-cloud-storage", version.ref = "googleCloudStorage" }
+googleapis-iam = { module = "com.google.apis:google-api-services-iam", version.ref = "googleApisIam" }
 
 [bundles]
 


### PR DESCRIPTION
## What this PR changes/adds

IAM interface allows to use ADC or existing service account to generate access tokens, instead of creating and deleting new service accounts for this purpose.
GCS provisioner adapted to make use of the new functions provided by IAM.

## Why it does that

The change avoids delays in the propagation of permissions to newly created service accounts.

## Note

When using Application Default Credentials (i.e. when a service account is not specified), avoid user credentials and select the appropriate service account,  http://cloud.google.com/docs/authentication/external/set-up-adc-on-cloud

## Linked Issue(s)

Closes #110 #118