### PR TITLE
feat: BigQuery common classes and provisioner

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -2,23 +2,13 @@ maven/mavencentral/com.apicatalog/carbon-did/0.0.2, Apache-2.0, approved, #9239
 maven/mavencentral/com.apicatalog/iron-verifiable-credentials/0.8.1, Apache-2.0, approved, #9234
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.1, Apache-2.0, approved, #8912
-maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.3, Apache-2.0, approved, #8912
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.10.3, Apache-2.0, approved, CQ21280
-maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.1, Apache-2.0, approved, #7947
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.3, Apache-2.0, approved, #7947
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.1, Apache-2.0, approved, #11606
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.16.1, Apache-2.0 AND MIT, approved, #11602
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.1, Apache-2.0, approved, #7934
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.3, Apache-2.0, approved, #7934
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.1, Apache-2.0, approved, #11605
-maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.1, Apache-2.0, approved, #8802
-maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.16.1, Apache-2.0, approved, #11855
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.16.1, Apache-2.0, approved, #11854
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.1, Apache-2.0, approved, #7930
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.1, Apache-2.0, approved, #11853
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.16.1, Apache-2.0, approved, #11851
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.1, Apache-2.0, approved, #9236
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.16.1, Apache-2.0, approved, #11858
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.15.3, Apache-2.0, approved, #9241
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.16.1, Apache-2.0, approved, #11856
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.16.1, Apache-2.0, approved, #11852
@@ -30,19 +20,19 @@ maven/mavencentral/com.google.android/annotations/4.1.1.4, Apache-2.0, approved,
 maven/mavencentral/com.google.api-client/google-api-client/2.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.api-client/google-api-client/2.3.0, Apache-2.0 AND BSD-3-Clause, approved, #13411
 maven/mavencentral/com.google.api.grpc/gapic-google-cloud-storage-v2/2.34.0-alpha, Apache-2.0, approved, #13418
-maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1/3.1.0, unknown, restricted, none
-maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1/3.2.0, unknown, restricted, none
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1/3.1.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1/3.2.0, , restricted, clearlydefined
 maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta1/0.173.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta1/0.174.0, unknown, restricted, none
-maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta2/0.173.0, unknown, restricted, none
-maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta2/0.174.0, unknown, restricted, none
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta1/0.174.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta2/0.173.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta2/0.174.0, , restricted, clearlydefined
 maven/mavencentral/com.google.api.grpc/grpc-google-cloud-storage-v2/2.34.0-alpha, Apache-2.0, approved, #13434
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.1.0, unknown, restricted, none
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.2.0, unknown, restricted, none
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.1.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.2.0, , restricted, clearlydefined
 maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta1/0.173.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta1/0.174.0, unknown, restricted, none
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.173.0, unknown, restricted, none
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.174.0, unknown, restricted, none
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta1/0.174.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.173.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.174.0, , restricted, clearlydefined
 maven/mavencentral/com.google.api.grpc/proto-google-cloud-iamcredentials-v1/2.36.0, Apache-2.0, approved, #13435
 maven/mavencentral/com.google.api.grpc/proto-google-cloud-secretmanager-v1/2.36.0, Apache-2.0, approved, #13395
 maven/mavencentral/com.google.api.grpc/proto-google-cloud-secretmanager-v1beta1/2.36.0, Apache-2.0, approved, #13409
@@ -54,16 +44,16 @@ maven/mavencentral/com.google.api/api-common/2.26.0, BSD-3-Clause, approved, #13
 maven/mavencentral/com.google.api/gax-grpc/2.43.0, BSD-3-Clause, approved, #13436
 maven/mavencentral/com.google.api/gax-httpjson/2.43.0, BSD-3-Clause, approved, #13396
 maven/mavencentral/com.google.api/gax/2.43.0, BSD-3-Clause, approved, #13405
-maven/mavencentral/com.google.apis/google-api-services-bigquery/v2-rev20240203-2.0.0, unknown, restricted, none
+maven/mavencentral/com.google.apis/google-api-services-bigquery/v2-rev20240203-2.0.0, , restricted, clearlydefined
 maven/mavencentral/com.google.apis/google-api-services-iam/v2-rev20240108-2.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.apis/google-api-services-storage/v1-rev20240209-2.0.0, Apache-2.0, approved, #13416
 maven/mavencentral/com.google.auth/google-auth-library-credentials/1.23.0, BSD-3-Clause, approved, #13420
 maven/mavencentral/com.google.auth/google-auth-library-oauth2-http/1.23.0, BSD-3-Clause, approved, #13437
 maven/mavencentral/com.google.auto.value/auto-value-annotations/1.10.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.auto.value/auto-value/1.10.4, Apache-2.0, approved, #8470
-maven/mavencentral/com.google.cloud/google-cloud-bigquery/2.37.2, unknown, restricted, none
-maven/mavencentral/com.google.cloud/google-cloud-bigquerystorage/3.1.0, unknown, restricted, none
-maven/mavencentral/com.google.cloud/google-cloud-bigquerystorage/3.2.0, unknown, restricted, none
+maven/mavencentral/com.google.cloud/google-cloud-bigquery/2.37.2, , restricted, clearlydefined
+maven/mavencentral/com.google.cloud/google-cloud-bigquerystorage/3.1.0, , restricted, clearlydefined
+maven/mavencentral/com.google.cloud/google-cloud-bigquerystorage/3.2.0, , restricted, clearlydefined
 maven/mavencentral/com.google.cloud/google-cloud-core-grpc/2.33.0, Apache-2.0, approved, #13408
 maven/mavencentral/com.google.cloud/google-cloud-core-http/2.33.0, Apache-2.0, approved, #13439
 maven/mavencentral/com.google.cloud/google-cloud-core/2.33.0, Apache-2.0, approved, #13406
@@ -125,7 +115,6 @@ maven/mavencentral/dev.failsafe/failsafe-okhttp/3.3.2, Apache-2.0, approved, #91
 maven/mavencentral/dev.failsafe/failsafe/3.3.1, Apache-2.0, approved, #9268
 maven/mavencentral/dev.failsafe/failsafe/3.3.2, Apache-2.0, approved, #9268
 maven/mavencentral/info.picocli/picocli/4.7.5, Apache-2.0, approved, #4365
-maven/mavencentral/io.github.classgraph/classgraph/4.8.154, MIT, approved, CQ22530
 maven/mavencentral/io.grpc/grpc-alts/1.61.1, Apache-2.0, approved, #13407
 maven/mavencentral/io.grpc/grpc-api/1.61.1, Apache-2.0, approved, #13422
 maven/mavencentral/io.grpc/grpc-auth/1.61.1, Apache-2.0, approved, #13401
@@ -154,20 +143,12 @@ maven/mavencentral/io.opentelemetry/opentelemetry-api/1.32.0, Apache-2.0, approv
 maven/mavencentral/io.opentelemetry/opentelemetry-context/1.32.0, Apache-2.0, approved, #11683
 maven/mavencentral/io.perfmark/perfmark-api/0.27.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.15, Apache-2.0, approved, #5947
-maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.20, Apache-2.0, approved, #5947
-maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.15, Apache-2.0, approved, #5929
-maven/mavencentral/io.swagger.core.v3/swagger-integration-jakarta/2.2.15, Apache-2.0, approved, #11475
-maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.2.15, Apache-2.0, approved, #11477
-maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.15, Apache-2.0, approved, #5919
 maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.0, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
 maven/mavencentral/jakarta.inject/jakarta.inject-api/2.0.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/jakarta.json/jakarta.json-api/2.1.1, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7907
 maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.0, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7697
 maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, ee4j.validation
 maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.rest
-maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/3.0.0, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/javax.annotation/javax.annotation-api/1.3.2, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ16910
 maven/mavencentral/junit/junit/4.13.2, EPL-2.0, approved, CQ23636
@@ -182,7 +163,6 @@ maven/mavencentral/org.apache.arrow/arrow-memory-core/15.0.0, Apache-2.0, approv
 maven/mavencentral/org.apache.arrow/arrow-memory-netty/15.0.0, Apache-2.0, approved, #12853
 maven/mavencentral/org.apache.arrow/arrow-vector/15.0.0, Apache-2.0 AND (Apache-2.0 AND FTL), approved, #12856
 maven/mavencentral/org.apache.commons/commons-compress/1.24.0, Apache-2.0 AND BSD-3-Clause AND bzip2-1.0.6 AND LicenseRef-Public-Domain, approved, #10368
-maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.8.1, Apache-2.0, approved, #815
 maven/mavencentral/org.apache.commons/commons-text/1.3, Apache-2.0, approved, clearlydefined
@@ -217,98 +197,42 @@ maven/mavencentral/org.codehaus.plexus/plexus-utils/3.3.0, , approved, CQ21066
 maven/mavencentral/org.conscrypt/conscrypt-openjdk-uber/2.5.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.eclipse.collections/eclipse-collections-api/11.1.0, EPL-1.0 OR BSD-3-Clause, approved, technology.collections
 maven/mavencentral/org.eclipse.collections/eclipse-collections/11.1.0, EPL-1.0 OR BSD-3-Clause, approved, technology.collections
-maven/mavencentral/org.eclipse.edc/api-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/asset-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/asset-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/auth-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/autodoc-processor/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/boot/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/catalog-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/catalog-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/catalog-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/configuration-filesystem/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/connector-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/contract-agreement-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/contract-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/contract-definition-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/contract-negotiation-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/contract-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/control-api-configuration/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/control-plane-aggregate-services/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/control-plane-api-client-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/control-plane-api-client/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/control-plane-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/control-plane-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/control-plane-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/core-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/crypto-common/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-address-http-data-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-client/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-control-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-plane-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-http-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-http/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-public-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-selector-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-selector-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-selector-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-plane-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-plane-util/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-api-configuration/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-catalog-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-catalog-http-dispatcher/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-catalog-transform/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-catalog/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-http-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-http-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-negotiation-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-negotiation-http-dispatcher/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-negotiation-transform/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-negotiation/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-transfer-process-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-transfer-process-http-dispatcher/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-transfer-process-transform/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-transfer-process/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-version-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/http-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/http/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/iam-mock/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/identity-did-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/identity-trust-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jersey-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jersey-providers/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jetty-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/json-ld-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/json-ld/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/junit/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jwt-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/management-api-configuration/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/management-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-definition-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/policy-engine-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/policy-engine/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/policy-evaluator/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/policy-model/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/state-machine/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/token-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/token-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transaction-datasource-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transaction-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transfer-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transfer-data-plane-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transfer-data-plane/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transfer-process-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transfer-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transform-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transform-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/util/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/validator-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/validator-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/vault-filesystem/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/web-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api/5.0.2, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-websocket-api/2.0.0, EPL-2.0 OR Apache-2.0, approved, rt.jetty
@@ -393,7 +317,6 @@ maven/mavencentral/org.reflections/reflections/0.10.2, Apache-2.0 AND WTFPL, app
 maven/mavencentral/org.rnorth.duct-tape/duct-tape/1.0.8, MIT, approved, clearlydefined
 maven/mavencentral/org.slf4j/slf4j-api/1.7.25, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.30, MIT, approved, CQ13368
-maven/mavencentral/org.slf4j/slf4j-api/1.7.35, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.36, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.7, MIT, approved, #10344
@@ -401,5 +324,3 @@ maven/mavencentral/org.testcontainers/testcontainers/1.19.7, Apache-2.0 AND MIT,
 maven/mavencentral/org.threeten/threeten-extra/1.7.2, BSD-3-Clause, approved, #6493
 maven/mavencentral/org.threeten/threetenbp/1.6.8, BSD-3-Clause, approved, #6750
 maven/mavencentral/org.xmlresolver/xmlresolver/5.2.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275
-maven/mavencentral/org.yaml/snakeyaml/2.2, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #10232

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -5,7 +5,6 @@ maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.1, Apache-2.0, approved, 
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.10.3, Apache-2.0, approved, CQ21280
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.3, Apache-2.0, approved, #7947
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.1, Apache-2.0, approved, #11606
-maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.16.0, Apache-2.0 AND MIT, approved, #11602
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.16.1, Apache-2.0 AND MIT, approved, #11602
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.3, Apache-2.0, approved, #7934
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.1, Apache-2.0, approved, #11605
@@ -13,38 +12,56 @@ maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.1
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.15.3, Apache-2.0, approved, #9241
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.16.1, Apache-2.0, approved, #11856
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.16.1, Apache-2.0, approved, #11852
-maven/mavencentral/com.github.docker-java/docker-java-api/3.3.4, Apache-2.0, approved, #10346
-maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.4, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #7946
-maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.4, Apache-2.0, approved, #7942
+maven/mavencentral/com.github.docker-java/docker-java-api/3.3.5, Apache-2.0, approved, #10346
+maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.5, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #7946
+maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.5, Apache-2.0, approved, #7942
 maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, approved, CQ21949
 maven/mavencentral/com.google.android/annotations/4.1.1.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.api-client/google-api-client/2.2.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.api.grpc/gapic-google-cloud-storage-v2/2.31.0-alpha, , restricted, clearlydefined
-maven/mavencentral/com.google.api.grpc/grpc-google-cloud-storage-v2/2.31.0-alpha, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-iamcredentials-v1/2.33.0, , restricted, clearlydefined
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-secretmanager-v1/2.33.0, , restricted, clearlydefined
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-secretmanager-v1beta1/2.33.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-storage-v2/2.31.0-alpha, , restricted, clearlydefined
-maven/mavencentral/com.google.api.grpc/proto-google-common-protos/2.30.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.api.grpc/proto-google-iam-admin-v1/3.28.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.api.grpc/proto-google-iam-v1/1.25.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.api/api-common/2.22.0, BSD-3-Clause, approved, clearlydefined
-maven/mavencentral/com.google.api/gax-grpc/2.39.0, BSD-3-Clause, approved, clearlydefined
-maven/mavencentral/com.google.api/gax-httpjson/2.39.0, BSD-3-Clause, approved, clearlydefined
-maven/mavencentral/com.google.api/gax/2.39.0, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/com.google.api-client/google-api-client/2.3.0, Apache-2.0 AND BSD-3-Clause, approved, #13411
+maven/mavencentral/com.google.api.grpc/gapic-google-cloud-storage-v2/2.34.0-alpha, Apache-2.0, approved, #13418
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1/3.1.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1/3.2.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta1/0.173.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta1/0.174.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta2/0.173.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta2/0.174.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-storage-v2/2.34.0-alpha, Apache-2.0, approved, #13434
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.1.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.2.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta1/0.173.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta1/0.174.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.173.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.174.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-iamcredentials-v1/2.36.0, Apache-2.0, approved, #13435
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-secretmanager-v1/2.36.0, Apache-2.0, approved, #13395
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-secretmanager-v1beta1/2.36.0, Apache-2.0, approved, #13409
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-storage-v2/2.34.0-alpha, Apache-2.0, approved, #13426
+maven/mavencentral/com.google.api.grpc/proto-google-common-protos/2.34.0, Apache-2.0, approved, #13421
+maven/mavencentral/com.google.api.grpc/proto-google-iam-admin-v1/3.31.0, Apache-2.0, approved, #13440
+maven/mavencentral/com.google.api.grpc/proto-google-iam-v1/1.29.0, Apache-2.0, approved, #13417
+maven/mavencentral/com.google.api/api-common/2.26.0, BSD-3-Clause, approved, #13419
+maven/mavencentral/com.google.api/gax-grpc/2.43.0, BSD-3-Clause, approved, #13436
+maven/mavencentral/com.google.api/gax-httpjson/2.43.0, BSD-3-Clause, approved, #13396
+maven/mavencentral/com.google.api/gax/2.43.0, BSD-3-Clause, approved, #13405
+maven/mavencentral/com.google.apis/google-api-services-bigquery/v2-rev20240203-2.0.0, , restricted, clearlydefined
 maven/mavencentral/com.google.apis/google-api-services-iam/v2-rev20240108-2.0.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.apis/google-api-services-storage/v1-rev20240105-2.0.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.auth/google-auth-library-credentials/1.21.0, BSD-3-Clause, approved, clearlydefined
-maven/mavencentral/com.google.auth/google-auth-library-oauth2-http/1.21.0, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/com.google.apis/google-api-services-storage/v1-rev20240209-2.0.0, Apache-2.0, approved, #13416
+maven/mavencentral/com.google.auth/google-auth-library-credentials/1.23.0, BSD-3-Clause, approved, #13420
+maven/mavencentral/com.google.auth/google-auth-library-oauth2-http/1.23.0, BSD-3-Clause, approved, #13437
 maven/mavencentral/com.google.auto.value/auto-value-annotations/1.10.4, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.cloud/google-cloud-core-grpc/2.29.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.cloud/google-cloud-core-http/2.29.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.cloud/google-cloud-core/2.29.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.cloud/google-cloud-iamcredentials/2.33.0, , restricted, clearlydefined
-maven/mavencentral/com.google.cloud/google-cloud-secretmanager/2.33.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.cloud/google-cloud-storage/2.31.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.cloud/google-iam-admin/3.28.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.cloud/libraries-bom/26.30.0, , restricted, clearlydefined
+maven/mavencentral/com.google.auto.value/auto-value/1.10.4, Apache-2.0, approved, #8470
+maven/mavencentral/com.google.cloud/google-cloud-bigquery/2.37.2, , restricted, clearlydefined
+maven/mavencentral/com.google.cloud/google-cloud-bigquerystorage/3.1.0, , restricted, clearlydefined
+maven/mavencentral/com.google.cloud/google-cloud-bigquerystorage/3.2.0, , restricted, clearlydefined
+maven/mavencentral/com.google.cloud/google-cloud-core-grpc/2.33.0, Apache-2.0, approved, #13408
+maven/mavencentral/com.google.cloud/google-cloud-core-http/2.33.0, Apache-2.0, approved, #13439
+maven/mavencentral/com.google.cloud/google-cloud-core/2.33.0, Apache-2.0, approved, #13406
+maven/mavencentral/com.google.cloud/google-cloud-iamcredentials/2.36.0, Apache-2.0, approved, #13441
+maven/mavencentral/com.google.cloud/google-cloud-secretmanager/2.36.0, Apache-2.0, approved, #13412
+maven/mavencentral/com.google.cloud/google-cloud-storage/2.34.0, Apache-2.0, approved, #13413
+maven/mavencentral/com.google.cloud/google-iam-admin/3.31.0, Apache-2.0, approved, #13432
+maven/mavencentral/com.google.cloud/libraries-bom/26.33.0, None, restricted, #13404
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
 maven/mavencentral/com.google.code.gson/gson/2.8.9, Apache-2.0, approved, CQ23496
@@ -54,35 +71,34 @@ maven/mavencentral/com.google.errorprone/error_prone_annotations/2.18.0, Apache-
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.21.1, Apache-2.0, approved, #9834
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.23.0, Apache-2.0, approved, #11083
+maven/mavencentral/com.google.errorprone/error_prone_annotations/2.24.1, Apache-2.0, approved, #12448
+maven/mavencentral/com.google.flatbuffers/flatbuffers-java/23.5.26, Apache-2.0, approved, #12857
 maven/mavencentral/com.google.guava/failureaccess/1.0.1, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/failureaccess/1.0.2, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/guava/29.0-android, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/guava/30.1.1-android, Apache-2.0 AND CC0-1.0 AND LicenseRef-Public-Domain, approved, CQ23244
 maven/mavencentral/com.google.guava/guava/31.1-android, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.guava/guava/31.1-jre, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/guava/32.0.0-android, Apache-2.0 AND CC0-1.0 AND CC-PDDC, approved, #8772
+maven/mavencentral/com.google.guava/guava/32.0.0-jre, Apache-2.0 AND CC0-1.0 AND CC-PDDC, approved, #8772
 maven/mavencentral/com.google.guava/guava/32.0.1-jre, Apache-2.0 AND CC0-1.0 AND CC-PDDC, approved, #8772
 maven/mavencentral/com.google.guava/guava/32.1.3-jre, Apache-2.0 AND CC0-1.0 AND LicenseRef-Public-Domain, approved, #9229
 maven/mavencentral/com.google.guava/guava/33.0.0-jre, Apache-2.0 AND CC0-1.0, approved, #12173
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
-maven/mavencentral/com.google.http-client/google-http-client-apache-v2/1.42.3, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.http-client/google-http-client-apache-v2/1.43.3, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.http-client/google-http-client-appengine/1.43.3, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.http-client/google-http-client-gson/1.42.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.http-client/google-http-client-gson/1.42.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.http-client/google-http-client-apache-v2/1.44.1, Apache-2.0, approved, #13430
+maven/mavencentral/com.google.http-client/google-http-client-appengine/1.44.1, Apache-2.0, approved, #13425
 maven/mavencentral/com.google.http-client/google-http-client-gson/1.43.3, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.http-client/google-http-client-jackson2/1.43.3, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.http-client/google-http-client/1.42.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.http-client/google-http-client/1.42.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.http-client/google-http-client-gson/1.44.1, Apache-2.0, approved, #13394
+maven/mavencentral/com.google.http-client/google-http-client-jackson2/1.44.1, Apache-2.0, approved, #13415
 maven/mavencentral/com.google.http-client/google-http-client/1.43.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.http-client/google-http-client/1.44.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.j2objc/j2objc-annotations/2.8, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.oauth-client/google-oauth-client/1.34.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.protobuf/protobuf-java-util/3.25.1, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/com.google.oauth-client/google-oauth-client/1.35.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.protobuf/protobuf-java-util/3.25.2, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.google.protobuf/protobuf-java/3.24.3, BSD-3-Clause, approved, clearlydefined
-maven/mavencentral/com.google.protobuf/protobuf-java/3.25.1, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/com.google.protobuf/protobuf-java/3.25.2, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.google.re2j/re2j/1.7, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.13.0, , restricted, clearlydefined
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.14.0, , restricted, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #11156
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.9.3, Apache-2.0 AND MPL-2.0, approved, #3225
@@ -92,36 +108,40 @@ maven/mavencentral/commons-beanutils/commons-beanutils/1.9.4, Apache-2.0, approv
 maven/mavencentral/commons-codec/commons-codec/1.11, Apache-2.0 AND BSD-3-Clause, approved, CQ15971
 maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause AND LicenseRef-Public-Domain, approved, CQ22641
 maven/mavencentral/commons-codec/commons-codec/1.16.0, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9157
+maven/mavencentral/commons-codec/commons-codec/1.16.1, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9157
 maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, CQ10385
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
 maven/mavencentral/dev.failsafe/failsafe-okhttp/3.3.2, Apache-2.0, approved, #9178
 maven/mavencentral/dev.failsafe/failsafe/3.3.1, Apache-2.0, approved, #9268
 maven/mavencentral/dev.failsafe/failsafe/3.3.2, Apache-2.0, approved, #9268
 maven/mavencentral/info.picocli/picocli/4.7.5, Apache-2.0, approved, #4365
-maven/mavencentral/io.grpc/grpc-alts/1.60.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.grpc/grpc-api/1.60.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.grpc/grpc-auth/1.60.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.grpc/grpc-alts/1.61.1, Apache-2.0, approved, #13407
+maven/mavencentral/io.grpc/grpc-api/1.61.1, Apache-2.0, approved, #13422
+maven/mavencentral/io.grpc/grpc-auth/1.61.1, Apache-2.0, approved, #13401
 maven/mavencentral/io.grpc/grpc-context/1.27.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.grpc/grpc-context/1.60.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.grpc/grpc-core/1.60.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.grpc/grpc-googleapis/1.60.0, , restricted, clearlydefined
-maven/mavencentral/io.grpc/grpc-grpclb/1.60.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.grpc/grpc-inprocess/1.60.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.grpc/grpc-netty-shaded/1.60.0, Apache-2.0, restricted, clearlydefined
-maven/mavencentral/io.grpc/grpc-protobuf-lite/1.60.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.grpc/grpc-protobuf/1.60.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.grpc/grpc-rls/1.60.0, , restricted, clearlydefined
-maven/mavencentral/io.grpc/grpc-services/1.60.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.grpc/grpc-stub/1.60.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.grpc/grpc-util/1.60.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.grpc/grpc-xds/1.60.0, , restricted, clearlydefined
+maven/mavencentral/io.grpc/grpc-context/1.60.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.grpc/grpc-context/1.61.1, None, restricted, #13414
+maven/mavencentral/io.grpc/grpc-core/1.61.1, Apache-2.0, approved, #13427
+maven/mavencentral/io.grpc/grpc-googleapis/1.61.1, Apache-2.0, approved, #13433
+maven/mavencentral/io.grpc/grpc-grpclb/1.61.1, Apache-2.0, approved, #13410
+maven/mavencentral/io.grpc/grpc-inprocess/1.61.1, Apache-2.0, approved, #13438
+maven/mavencentral/io.grpc/grpc-netty-shaded/1.61.1, None, restricted, #13431
+maven/mavencentral/io.grpc/grpc-protobuf-lite/1.61.1, Apache-2.0, approved, #13423
+maven/mavencentral/io.grpc/grpc-protobuf/1.61.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.grpc/grpc-rls/1.61.1, Apache-2.0, approved, #13429
+maven/mavencentral/io.grpc/grpc-services/1.61.1, Apache-2.0, approved, #13397
+maven/mavencentral/io.grpc/grpc-stub/1.61.1, Apache-2.0, approved, #13398
+maven/mavencentral/io.grpc/grpc-util/1.61.1, Apache-2.0, approved, #13428
+maven/mavencentral/io.grpc/grpc-xds/1.61.1, Apache-2.0, approved, #13424
+maven/mavencentral/io.netty/netty-buffer/4.1.104.Final, Apache-2.0, approved, CQ21842
+maven/mavencentral/io.netty/netty-common/4.1.104.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
 maven/mavencentral/io.opencensus/opencensus-api/0.31.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.opencensus/opencensus-contrib-http-util/0.31.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.opencensus/opencensus-proto/0.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.32.0, Apache-2.0, approved, #11684
 maven/mavencentral/io.opentelemetry/opentelemetry-api/1.32.0, Apache-2.0, approved, #11682
 maven/mavencentral/io.opentelemetry/opentelemetry-context/1.32.0, Apache-2.0, approved, #11683
-maven/mavencentral/io.perfmark/perfmark-api/0.26.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.perfmark/perfmark-api/0.27.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.0, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
@@ -132,11 +152,16 @@ maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0, EPL-2.0 OR GPL-2.0-onl
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/javax.annotation/javax.annotation-api/1.3.2, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ16910
 maven/mavencentral/junit/junit/4.13.2, EPL-2.0, approved, CQ23636
-maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.11, Apache-2.0, approved, #7164
+maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.12, Apache-2.0, approved, #7164
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.11, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.bytebuddy/byte-buddy/1.14.12, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #6709
 maven/mavencentral/net.sf.saxon/Saxon-HE/12.4, MPL-2.0 AND (MPL-2.0 AND Apache-2.0) AND (MPL-2.0 AND LicenseRef-X11-style) AND MPL-1.0 AND W3C, approved, #12716
 maven/mavencentral/org.antlr/antlr4-runtime/4.13.1, BSD-3-Clause, approved, #10767
+maven/mavencentral/org.apache.arrow/arrow-format/15.0.0, Apache-2.0, approved, #12854
+maven/mavencentral/org.apache.arrow/arrow-memory-core/15.0.0, Apache-2.0, approved, #12855
+maven/mavencentral/org.apache.arrow/arrow-memory-netty/15.0.0, Apache-2.0, approved, #12853
+maven/mavencentral/org.apache.arrow/arrow-vector/15.0.0, Apache-2.0 AND (Apache-2.0 AND FTL), approved, #12856
 maven/mavencentral/org.apache.commons/commons-compress/1.24.0, Apache-2.0 AND BSD-3-Clause AND bzip2-1.0.6 AND LicenseRef-Public-Domain, approved, #10368
 maven/mavencentral/org.apache.commons/commons-lang3/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.8.1, Apache-2.0, approved, #815
@@ -159,8 +184,8 @@ maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.77, MIT, approved, #11593
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.77, MIT AND CC0-1.0, approved, #11595
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.77, MIT, approved, #11596
+maven/mavencentral/org.checkerframework/checker-compat-qual/2.5.6, GPL-2.0-only with Classpath-Exception-2.0, approved, #11598
 maven/mavencentral/org.checkerframework/checker-qual/3.37.0, MIT, approved, clearlydefined
-maven/mavencentral/org.checkerframework/checker-qual/3.40.0, MIT, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.41.0, MIT, approved, #12032
 maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, clearlydefined
 maven/mavencentral/org.codehaus.mojo/animal-sniffer-annotations/1.23, MIT, approved, clearlydefined
@@ -170,6 +195,8 @@ maven/mavencentral/org.codehaus.plexus/plexus-container-default/2.1.0, Apache-2.
 maven/mavencentral/org.codehaus.plexus/plexus-utils/3.1.1, , approved, CQ16492
 maven/mavencentral/org.codehaus.plexus/plexus-utils/3.3.0, , approved, CQ21066
 maven/mavencentral/org.conscrypt/conscrypt-openjdk-uber/2.5.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.eclipse.collections/eclipse-collections-api/11.1.0, EPL-1.0 OR BSD-3-Clause, approved, technology.collections
+maven/mavencentral/org.eclipse.collections/eclipse-collections/11.1.0, EPL-1.0 OR BSD-3-Clause, approved, technology.collections
 maven/mavencentral/org.eclipse.edc/autodoc-processor/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/boot/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/catalog-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -259,6 +286,7 @@ maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib/1.9.10, Apache-2.0, approv
 maven/mavencentral/org.jetbrains/annotations/13.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains/annotations/17.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains/annotations/24.1.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.json/json/20231013, OTHER, restricted, clearlydefined
 maven/mavencentral/org.junit-pioneer/junit-pioneer/2.2.0, EPL-2.0, approved, #11857
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.1, EPL-2.0, approved, #9714
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.2, EPL-2.0, approved, #9714
@@ -275,8 +303,8 @@ maven/mavencentral/org.junit/junit-bom/5.10.1, EPL-2.0, approved, #9844
 maven/mavencentral/org.junit/junit-bom/5.10.2, EPL-2.0, approved, #9844
 maven/mavencentral/org.junit/junit-bom/5.9.2, EPL-2.0, approved, #4711
 maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.15, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ21484
+maven/mavencentral/org.mockito/mockito-core/5.11.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #13505
 maven/mavencentral/org.mockito/mockito-core/5.2.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #7401
-maven/mavencentral/org.mockito/mockito-core/5.9.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #12774
 maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.opentest4j/opentest4j/1.3.0, Apache-2.0, approved, #9713
 maven/mavencentral/org.ow2.asm/asm-commons/9.5, BSD-3-Clause, approved, #7553
@@ -291,7 +319,8 @@ maven/mavencentral/org.slf4j/slf4j-api/1.7.25, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.30, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.36, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
-maven/mavencentral/org.testcontainers/junit-jupiter/1.19.5, MIT, approved, #10344
-maven/mavencentral/org.testcontainers/testcontainers/1.19.5, Apache-2.0 AND MIT, approved, #10347
+maven/mavencentral/org.testcontainers/junit-jupiter/1.19.6, MIT, approved, #10344
+maven/mavencentral/org.testcontainers/testcontainers/1.19.6, Apache-2.0 AND MIT, approved, #10347
+maven/mavencentral/org.threeten/threeten-extra/1.7.2, BSD-3-Clause, approved, #6493
 maven/mavencentral/org.threeten/threetenbp/1.6.8, BSD-3-Clause, approved, #6750
 maven/mavencentral/org.xmlresolver/xmlresolver/5.2.2, Apache-2.0, approved, clearlydefined

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -2,37 +2,47 @@ maven/mavencentral/com.apicatalog/carbon-did/0.0.2, Apache-2.0, approved, #9239
 maven/mavencentral/com.apicatalog/iron-verifiable-credentials/0.8.1, Apache-2.0, approved, #9234
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.1, Apache-2.0, approved, #8912
+maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.3, Apache-2.0, approved, #8912
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.10.3, Apache-2.0, approved, CQ21280
+maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.1, Apache-2.0, approved, #7947
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.3, Apache-2.0, approved, #7947
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.1, Apache-2.0, approved, #11606
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.16.1, Apache-2.0 AND MIT, approved, #11602
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.1, Apache-2.0, approved, #7934
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.3, Apache-2.0, approved, #7934
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.1, Apache-2.0, approved, #11605
+maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.1, Apache-2.0, approved, #8802
+maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.16.1, Apache-2.0, approved, #11855
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.16.1, Apache-2.0, approved, #11854
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.1, Apache-2.0, approved, #7930
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.1, Apache-2.0, approved, #11853
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.16.1, Apache-2.0, approved, #11851
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.1, Apache-2.0, approved, #9236
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.16.1, Apache-2.0, approved, #11858
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.15.3, Apache-2.0, approved, #9241
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.16.1, Apache-2.0, approved, #11856
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.16.1, Apache-2.0, approved, #11852
-maven/mavencentral/com.github.docker-java/docker-java-api/3.3.5, Apache-2.0, approved, #10346
-maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.5, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #7946
-maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.5, Apache-2.0, approved, #7942
+maven/mavencentral/com.github.docker-java/docker-java-api/3.3.6, Apache-2.0, approved, #10346
+maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.6, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #7946
+maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.6, Apache-2.0, approved, #7942
 maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, approved, CQ21949
 maven/mavencentral/com.google.android/annotations/4.1.1.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.api-client/google-api-client/2.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.api-client/google-api-client/2.3.0, Apache-2.0 AND BSD-3-Clause, approved, #13411
 maven/mavencentral/com.google.api.grpc/gapic-google-cloud-storage-v2/2.34.0-alpha, Apache-2.0, approved, #13418
-maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1/3.1.0, , restricted, clearlydefined
-maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1/3.2.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1/3.1.0, unknown, restricted, none
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1/3.2.0, unknown, restricted, none
 maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta1/0.173.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta1/0.174.0, , restricted, clearlydefined
-maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta2/0.173.0, , restricted, clearlydefined
-maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta2/0.174.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta1/0.174.0, unknown, restricted, none
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta2/0.173.0, unknown, restricted, none
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta2/0.174.0, unknown, restricted, none
 maven/mavencentral/com.google.api.grpc/grpc-google-cloud-storage-v2/2.34.0-alpha, Apache-2.0, approved, #13434
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.1.0, , restricted, clearlydefined
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.2.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.1.0, unknown, restricted, none
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.2.0, unknown, restricted, none
 maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta1/0.173.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta1/0.174.0, , restricted, clearlydefined
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.173.0, , restricted, clearlydefined
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.174.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta1/0.174.0, unknown, restricted, none
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.173.0, unknown, restricted, none
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.174.0, unknown, restricted, none
 maven/mavencentral/com.google.api.grpc/proto-google-cloud-iamcredentials-v1/2.36.0, Apache-2.0, approved, #13435
 maven/mavencentral/com.google.api.grpc/proto-google-cloud-secretmanager-v1/2.36.0, Apache-2.0, approved, #13395
 maven/mavencentral/com.google.api.grpc/proto-google-cloud-secretmanager-v1beta1/2.36.0, Apache-2.0, approved, #13409
@@ -44,16 +54,16 @@ maven/mavencentral/com.google.api/api-common/2.26.0, BSD-3-Clause, approved, #13
 maven/mavencentral/com.google.api/gax-grpc/2.43.0, BSD-3-Clause, approved, #13436
 maven/mavencentral/com.google.api/gax-httpjson/2.43.0, BSD-3-Clause, approved, #13396
 maven/mavencentral/com.google.api/gax/2.43.0, BSD-3-Clause, approved, #13405
-maven/mavencentral/com.google.apis/google-api-services-bigquery/v2-rev20240203-2.0.0, , restricted, clearlydefined
+maven/mavencentral/com.google.apis/google-api-services-bigquery/v2-rev20240203-2.0.0, unknown, restricted, none
 maven/mavencentral/com.google.apis/google-api-services-iam/v2-rev20240108-2.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.apis/google-api-services-storage/v1-rev20240209-2.0.0, Apache-2.0, approved, #13416
 maven/mavencentral/com.google.auth/google-auth-library-credentials/1.23.0, BSD-3-Clause, approved, #13420
 maven/mavencentral/com.google.auth/google-auth-library-oauth2-http/1.23.0, BSD-3-Clause, approved, #13437
 maven/mavencentral/com.google.auto.value/auto-value-annotations/1.10.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.auto.value/auto-value/1.10.4, Apache-2.0, approved, #8470
-maven/mavencentral/com.google.cloud/google-cloud-bigquery/2.37.2, , restricted, clearlydefined
-maven/mavencentral/com.google.cloud/google-cloud-bigquerystorage/3.1.0, , restricted, clearlydefined
-maven/mavencentral/com.google.cloud/google-cloud-bigquerystorage/3.2.0, , restricted, clearlydefined
+maven/mavencentral/com.google.cloud/google-cloud-bigquery/2.37.2, unknown, restricted, none
+maven/mavencentral/com.google.cloud/google-cloud-bigquerystorage/3.1.0, unknown, restricted, none
+maven/mavencentral/com.google.cloud/google-cloud-bigquerystorage/3.2.0, unknown, restricted, none
 maven/mavencentral/com.google.cloud/google-cloud-core-grpc/2.33.0, Apache-2.0, approved, #13408
 maven/mavencentral/com.google.cloud/google-cloud-core-http/2.33.0, Apache-2.0, approved, #13439
 maven/mavencentral/com.google.cloud/google-cloud-core/2.33.0, Apache-2.0, approved, #13406
@@ -98,7 +108,7 @@ maven/mavencentral/com.google.protobuf/protobuf-java/3.24.3, BSD-3-Clause, appro
 maven/mavencentral/com.google.protobuf/protobuf-java/3.25.2, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.google.re2j/re2j/1.7, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.14.0, , restricted, clearlydefined
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.14.0, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #13562
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #11156
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.9.3, Apache-2.0 AND MPL-2.0, approved, #3225
@@ -115,6 +125,7 @@ maven/mavencentral/dev.failsafe/failsafe-okhttp/3.3.2, Apache-2.0, approved, #91
 maven/mavencentral/dev.failsafe/failsafe/3.3.1, Apache-2.0, approved, #9268
 maven/mavencentral/dev.failsafe/failsafe/3.3.2, Apache-2.0, approved, #9268
 maven/mavencentral/info.picocli/picocli/4.7.5, Apache-2.0, approved, #4365
+maven/mavencentral/io.github.classgraph/classgraph/4.8.154, MIT, approved, CQ22530
 maven/mavencentral/io.grpc/grpc-alts/1.61.1, Apache-2.0, approved, #13407
 maven/mavencentral/io.grpc/grpc-api/1.61.1, Apache-2.0, approved, #13422
 maven/mavencentral/io.grpc/grpc-auth/1.61.1, Apache-2.0, approved, #13401
@@ -143,12 +154,20 @@ maven/mavencentral/io.opentelemetry/opentelemetry-api/1.32.0, Apache-2.0, approv
 maven/mavencentral/io.opentelemetry/opentelemetry-context/1.32.0, Apache-2.0, approved, #11683
 maven/mavencentral/io.perfmark/perfmark-api/0.27.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.15, Apache-2.0, approved, #5947
+maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.20, Apache-2.0, approved, #5947
+maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.15, Apache-2.0, approved, #5929
+maven/mavencentral/io.swagger.core.v3/swagger-integration-jakarta/2.2.15, Apache-2.0, approved, #11475
+maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.2.15, Apache-2.0, approved, #11477
+maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.15, Apache-2.0, approved, #5919
 maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.0, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
 maven/mavencentral/jakarta.inject/jakarta.inject-api/2.0.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/jakarta.json/jakarta.json-api/2.1.1, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7907
 maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.0, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7697
 maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, ee4j.validation
 maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.rest
+maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/3.0.0, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/javax.annotation/javax.annotation-api/1.3.2, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ16910
 maven/mavencentral/junit/junit/4.13.2, EPL-2.0, approved, CQ23636
@@ -163,6 +182,7 @@ maven/mavencentral/org.apache.arrow/arrow-memory-core/15.0.0, Apache-2.0, approv
 maven/mavencentral/org.apache.arrow/arrow-memory-netty/15.0.0, Apache-2.0, approved, #12853
 maven/mavencentral/org.apache.arrow/arrow-vector/15.0.0, Apache-2.0 AND (Apache-2.0 AND FTL), approved, #12856
 maven/mavencentral/org.apache.commons/commons-compress/1.24.0, Apache-2.0 AND BSD-3-Clause AND bzip2-1.0.6 AND LicenseRef-Public-Domain, approved, #10368
+maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.8.1, Apache-2.0, approved, #815
 maven/mavencentral/org.apache.commons/commons-text/1.3, Apache-2.0, approved, clearlydefined
@@ -197,42 +217,98 @@ maven/mavencentral/org.codehaus.plexus/plexus-utils/3.3.0, , approved, CQ21066
 maven/mavencentral/org.conscrypt/conscrypt-openjdk-uber/2.5.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.eclipse.collections/eclipse-collections-api/11.1.0, EPL-1.0 OR BSD-3-Clause, approved, technology.collections
 maven/mavencentral/org.eclipse.collections/eclipse-collections/11.1.0, EPL-1.0 OR BSD-3-Clause, approved, technology.collections
+maven/mavencentral/org.eclipse.edc/api-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/asset-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/asset-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/auth-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/autodoc-processor/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/boot/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/catalog-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/catalog-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/catalog-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/configuration-filesystem/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/connector-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/contract-agreement-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/contract-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/contract-definition-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/contract-negotiation-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/contract-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/control-api-configuration/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/control-plane-aggregate-services/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/control-plane-api-client-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/control-plane-api-client/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/control-plane-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/control-plane-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/control-plane-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/core-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/crypto-common/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-address-http-data-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-client/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-control-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-plane-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-http-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-http/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-public-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-selector-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-selector-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-selector-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-plane-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-plane-util/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-api-configuration/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-catalog-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-catalog-http-dispatcher/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-catalog-transform/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-catalog/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-http-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-http-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-negotiation-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-negotiation-http-dispatcher/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-negotiation-transform/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-negotiation/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-transfer-process-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-transfer-process-http-dispatcher/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-transfer-process-transform/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-transfer-process/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-version-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/http-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/http/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/iam-mock/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/identity-did-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/identity-trust-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jersey-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jersey-providers/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jetty-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/json-ld-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/json-ld/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/junit/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jwt-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/management-api-configuration/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/management-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-definition-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/policy-engine-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/policy-engine/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/policy-evaluator/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/policy-model/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/state-machine/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/token-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/token-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transaction-datasource-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transaction-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transfer-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transfer-data-plane-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transfer-data-plane/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transfer-process-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transfer-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transform-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transform-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/util/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/validator-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/validator-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/vault-filesystem/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/web-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api/5.0.2, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-websocket-api/2.0.0, EPL-2.0 OR Apache-2.0, approved, rt.jetty
@@ -317,10 +393,13 @@ maven/mavencentral/org.reflections/reflections/0.10.2, Apache-2.0 AND WTFPL, app
 maven/mavencentral/org.rnorth.duct-tape/duct-tape/1.0.8, MIT, approved, clearlydefined
 maven/mavencentral/org.slf4j/slf4j-api/1.7.25, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.30, MIT, approved, CQ13368
+maven/mavencentral/org.slf4j/slf4j-api/1.7.35, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.36, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
-maven/mavencentral/org.testcontainers/junit-jupiter/1.19.6, MIT, approved, #10344
-maven/mavencentral/org.testcontainers/testcontainers/1.19.6, Apache-2.0 AND MIT, approved, #10347
+maven/mavencentral/org.testcontainers/junit-jupiter/1.19.7, MIT, approved, #10344
+maven/mavencentral/org.testcontainers/testcontainers/1.19.7, Apache-2.0 AND MIT, approved, #10347
 maven/mavencentral/org.threeten/threeten-extra/1.7.2, BSD-3-Clause, approved, #6493
 maven/mavencentral/org.threeten/threetenbp/1.6.8, BSD-3-Clause, approved, #6750
 maven/mavencentral/org.xmlresolver/xmlresolver/5.2.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275
+maven/mavencentral/org.yaml/snakeyaml/2.2, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #10232

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -20,7 +20,19 @@ maven/mavencentral/com.google.android/annotations/4.1.1.4, Apache-2.0, approved,
 maven/mavencentral/com.google.api-client/google-api-client/2.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.api-client/google-api-client/2.3.0, Apache-2.0 AND BSD-3-Clause, approved, #13411
 maven/mavencentral/com.google.api.grpc/gapic-google-cloud-storage-v2/2.34.0-alpha, Apache-2.0, approved, #13418
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1/3.1.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1/3.2.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta1/0.173.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta1/0.174.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta2/0.173.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta2/0.174.0, , restricted, clearlydefined
 maven/mavencentral/com.google.api.grpc/grpc-google-cloud-storage-v2/2.34.0-alpha, Apache-2.0, approved, #13434
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.1.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.2.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta1/0.173.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta1/0.174.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.173.0, , restricted, clearlydefined
+maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.174.0, , restricted, clearlydefined
 maven/mavencentral/com.google.api.grpc/proto-google-cloud-iamcredentials-v1/2.36.0, Apache-2.0, approved, #13435
 maven/mavencentral/com.google.api.grpc/proto-google-cloud-secretmanager-v1/2.36.0, Apache-2.0, approved, #13395
 maven/mavencentral/com.google.api.grpc/proto-google-cloud-secretmanager-v1beta1/2.36.0, Apache-2.0, approved, #13409
@@ -32,11 +44,16 @@ maven/mavencentral/com.google.api/api-common/2.26.0, BSD-3-Clause, approved, #13
 maven/mavencentral/com.google.api/gax-grpc/2.43.0, BSD-3-Clause, approved, #13436
 maven/mavencentral/com.google.api/gax-httpjson/2.43.0, BSD-3-Clause, approved, #13396
 maven/mavencentral/com.google.api/gax/2.43.0, BSD-3-Clause, approved, #13405
+maven/mavencentral/com.google.apis/google-api-services-bigquery/v2-rev20240203-2.0.0, , restricted, clearlydefined
 maven/mavencentral/com.google.apis/google-api-services-iam/v2-rev20240108-2.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.apis/google-api-services-storage/v1-rev20240209-2.0.0, Apache-2.0, approved, #13416
 maven/mavencentral/com.google.auth/google-auth-library-credentials/1.23.0, BSD-3-Clause, approved, #13420
 maven/mavencentral/com.google.auth/google-auth-library-oauth2-http/1.23.0, BSD-3-Clause, approved, #13437
 maven/mavencentral/com.google.auto.value/auto-value-annotations/1.10.4, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.auto.value/auto-value/1.10.4, Apache-2.0, approved, #8470
+maven/mavencentral/com.google.cloud/google-cloud-bigquery/2.37.2, , restricted, clearlydefined
+maven/mavencentral/com.google.cloud/google-cloud-bigquerystorage/3.1.0, , restricted, clearlydefined
+maven/mavencentral/com.google.cloud/google-cloud-bigquerystorage/3.2.0, , restricted, clearlydefined
 maven/mavencentral/com.google.cloud/google-cloud-core-grpc/2.33.0, Apache-2.0, approved, #13408
 maven/mavencentral/com.google.cloud/google-cloud-core-http/2.33.0, Apache-2.0, approved, #13439
 maven/mavencentral/com.google.cloud/google-cloud-core/2.33.0, Apache-2.0, approved, #13406
@@ -55,6 +72,7 @@ maven/mavencentral/com.google.errorprone/error_prone_annotations/2.21.1, Apache-
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.23.0, Apache-2.0, approved, #11083
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.24.1, Apache-2.0, approved, #12448
+maven/mavencentral/com.google.flatbuffers/flatbuffers-java/23.5.26, Apache-2.0, approved, #12857
 maven/mavencentral/com.google.guava/failureaccess/1.0.1, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/failureaccess/1.0.2, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/guava/29.0-android, Apache-2.0, approved, clearlydefined
@@ -115,6 +133,8 @@ maven/mavencentral/io.grpc/grpc-services/1.61.1, Apache-2.0, approved, #13397
 maven/mavencentral/io.grpc/grpc-stub/1.61.1, Apache-2.0, approved, #13398
 maven/mavencentral/io.grpc/grpc-util/1.61.1, Apache-2.0, approved, #13428
 maven/mavencentral/io.grpc/grpc-xds/1.61.1, Apache-2.0, approved, #13424
+maven/mavencentral/io.netty/netty-buffer/4.1.104.Final, Apache-2.0, approved, CQ21842
+maven/mavencentral/io.netty/netty-common/4.1.104.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
 maven/mavencentral/io.opencensus/opencensus-api/0.31.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.opencensus/opencensus-contrib-http-util/0.31.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.opencensus/opencensus-proto/0.2.0, Apache-2.0, approved, clearlydefined
@@ -138,6 +158,10 @@ maven/mavencentral/net.bytebuddy/byte-buddy/1.14.12, Apache-2.0 AND BSD-3-Clause
 maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #6709
 maven/mavencentral/net.sf.saxon/Saxon-HE/12.4, MPL-2.0 AND (MPL-2.0 AND Apache-2.0) AND (MPL-2.0 AND LicenseRef-X11-style) AND MPL-1.0 AND W3C, approved, #12716
 maven/mavencentral/org.antlr/antlr4-runtime/4.13.1, BSD-3-Clause, approved, #10767
+maven/mavencentral/org.apache.arrow/arrow-format/15.0.0, Apache-2.0, approved, #12854
+maven/mavencentral/org.apache.arrow/arrow-memory-core/15.0.0, Apache-2.0, approved, #12855
+maven/mavencentral/org.apache.arrow/arrow-memory-netty/15.0.0, Apache-2.0, approved, #12853
+maven/mavencentral/org.apache.arrow/arrow-vector/15.0.0, Apache-2.0 AND (Apache-2.0 AND FTL), approved, #12856
 maven/mavencentral/org.apache.commons/commons-compress/1.24.0, Apache-2.0 AND BSD-3-Clause AND bzip2-1.0.6 AND LicenseRef-Public-Domain, approved, #10368
 maven/mavencentral/org.apache.commons/commons-lang3/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.8.1, Apache-2.0, approved, #815
@@ -160,6 +184,7 @@ maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.77, MIT, approved, #11593
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.77, MIT AND CC0-1.0, approved, #11595
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.77, MIT, approved, #11596
+maven/mavencentral/org.checkerframework/checker-compat-qual/2.5.6, GPL-2.0-only with Classpath-Exception-2.0, approved, #11598
 maven/mavencentral/org.checkerframework/checker-qual/3.37.0, MIT, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.41.0, MIT, approved, #12032
 maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, clearlydefined
@@ -170,6 +195,8 @@ maven/mavencentral/org.codehaus.plexus/plexus-container-default/2.1.0, Apache-2.
 maven/mavencentral/org.codehaus.plexus/plexus-utils/3.1.1, , approved, CQ16492
 maven/mavencentral/org.codehaus.plexus/plexus-utils/3.3.0, , approved, CQ21066
 maven/mavencentral/org.conscrypt/conscrypt-openjdk-uber/2.5.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.eclipse.collections/eclipse-collections-api/11.1.0, EPL-1.0 OR BSD-3-Clause, approved, technology.collections
+maven/mavencentral/org.eclipse.collections/eclipse-collections/11.1.0, EPL-1.0 OR BSD-3-Clause, approved, technology.collections
 maven/mavencentral/org.eclipse.edc/autodoc-processor/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/boot/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/catalog-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -259,6 +286,7 @@ maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib/1.9.10, Apache-2.0, approv
 maven/mavencentral/org.jetbrains/annotations/13.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains/annotations/17.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains/annotations/24.1.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.json/json/20231013, OTHER, restricted, clearlydefined
 maven/mavencentral/org.junit-pioneer/junit-pioneer/2.2.0, EPL-2.0, approved, #11857
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.1, EPL-2.0, approved, #9714
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.2, EPL-2.0, approved, #9714
@@ -293,5 +321,6 @@ maven/mavencentral/org.slf4j/slf4j-api/1.7.36, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.7, MIT, approved, #10344
 maven/mavencentral/org.testcontainers/testcontainers/1.19.7, Apache-2.0 AND MIT, approved, #10347
+maven/mavencentral/org.threeten/threeten-extra/1.7.2, BSD-3-Clause, approved, #6493
 maven/mavencentral/org.threeten/threetenbp/1.6.8, BSD-3-Clause, approved, #6750
 maven/mavencentral/org.xmlresolver/xmlresolver/5.2.2, Apache-2.0, approved, clearlydefined

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -20,19 +20,7 @@ maven/mavencentral/com.google.android/annotations/4.1.1.4, Apache-2.0, approved,
 maven/mavencentral/com.google.api-client/google-api-client/2.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.api-client/google-api-client/2.3.0, Apache-2.0 AND BSD-3-Clause, approved, #13411
 maven/mavencentral/com.google.api.grpc/gapic-google-cloud-storage-v2/2.34.0-alpha, Apache-2.0, approved, #13418
-maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1/3.1.0, , restricted, clearlydefined
-maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1/3.2.0, , restricted, clearlydefined
-maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta1/0.173.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta1/0.174.0, , restricted, clearlydefined
-maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta2/0.173.0, , restricted, clearlydefined
-maven/mavencentral/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1beta2/0.174.0, , restricted, clearlydefined
 maven/mavencentral/com.google.api.grpc/grpc-google-cloud-storage-v2/2.34.0-alpha, Apache-2.0, approved, #13434
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.1.0, , restricted, clearlydefined
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.2.0, , restricted, clearlydefined
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta1/0.173.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta1/0.174.0, , restricted, clearlydefined
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.173.0, , restricted, clearlydefined
-maven/mavencentral/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.174.0, , restricted, clearlydefined
 maven/mavencentral/com.google.api.grpc/proto-google-cloud-iamcredentials-v1/2.36.0, Apache-2.0, approved, #13435
 maven/mavencentral/com.google.api.grpc/proto-google-cloud-secretmanager-v1/2.36.0, Apache-2.0, approved, #13395
 maven/mavencentral/com.google.api.grpc/proto-google-cloud-secretmanager-v1beta1/2.36.0, Apache-2.0, approved, #13409
@@ -44,16 +32,11 @@ maven/mavencentral/com.google.api/api-common/2.26.0, BSD-3-Clause, approved, #13
 maven/mavencentral/com.google.api/gax-grpc/2.43.0, BSD-3-Clause, approved, #13436
 maven/mavencentral/com.google.api/gax-httpjson/2.43.0, BSD-3-Clause, approved, #13396
 maven/mavencentral/com.google.api/gax/2.43.0, BSD-3-Clause, approved, #13405
-maven/mavencentral/com.google.apis/google-api-services-bigquery/v2-rev20240203-2.0.0, , restricted, clearlydefined
 maven/mavencentral/com.google.apis/google-api-services-iam/v2-rev20240108-2.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.apis/google-api-services-storage/v1-rev20240209-2.0.0, Apache-2.0, approved, #13416
 maven/mavencentral/com.google.auth/google-auth-library-credentials/1.23.0, BSD-3-Clause, approved, #13420
 maven/mavencentral/com.google.auth/google-auth-library-oauth2-http/1.23.0, BSD-3-Clause, approved, #13437
 maven/mavencentral/com.google.auto.value/auto-value-annotations/1.10.4, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.auto.value/auto-value/1.10.4, Apache-2.0, approved, #8470
-maven/mavencentral/com.google.cloud/google-cloud-bigquery/2.37.2, , restricted, clearlydefined
-maven/mavencentral/com.google.cloud/google-cloud-bigquerystorage/3.1.0, , restricted, clearlydefined
-maven/mavencentral/com.google.cloud/google-cloud-bigquerystorage/3.2.0, , restricted, clearlydefined
 maven/mavencentral/com.google.cloud/google-cloud-core-grpc/2.33.0, Apache-2.0, approved, #13408
 maven/mavencentral/com.google.cloud/google-cloud-core-http/2.33.0, Apache-2.0, approved, #13439
 maven/mavencentral/com.google.cloud/google-cloud-core/2.33.0, Apache-2.0, approved, #13406
@@ -72,7 +55,6 @@ maven/mavencentral/com.google.errorprone/error_prone_annotations/2.21.1, Apache-
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.23.0, Apache-2.0, approved, #11083
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.24.1, Apache-2.0, approved, #12448
-maven/mavencentral/com.google.flatbuffers/flatbuffers-java/23.5.26, Apache-2.0, approved, #12857
 maven/mavencentral/com.google.guava/failureaccess/1.0.1, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/failureaccess/1.0.2, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/guava/29.0-android, Apache-2.0, approved, clearlydefined
@@ -133,8 +115,6 @@ maven/mavencentral/io.grpc/grpc-services/1.61.1, Apache-2.0, approved, #13397
 maven/mavencentral/io.grpc/grpc-stub/1.61.1, Apache-2.0, approved, #13398
 maven/mavencentral/io.grpc/grpc-util/1.61.1, Apache-2.0, approved, #13428
 maven/mavencentral/io.grpc/grpc-xds/1.61.1, Apache-2.0, approved, #13424
-maven/mavencentral/io.netty/netty-buffer/4.1.104.Final, Apache-2.0, approved, CQ21842
-maven/mavencentral/io.netty/netty-common/4.1.104.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
 maven/mavencentral/io.opencensus/opencensus-api/0.31.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.opencensus/opencensus-contrib-http-util/0.31.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.opencensus/opencensus-proto/0.2.0, Apache-2.0, approved, clearlydefined
@@ -158,10 +138,6 @@ maven/mavencentral/net.bytebuddy/byte-buddy/1.14.12, Apache-2.0 AND BSD-3-Clause
 maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #6709
 maven/mavencentral/net.sf.saxon/Saxon-HE/12.4, MPL-2.0 AND (MPL-2.0 AND Apache-2.0) AND (MPL-2.0 AND LicenseRef-X11-style) AND MPL-1.0 AND W3C, approved, #12716
 maven/mavencentral/org.antlr/antlr4-runtime/4.13.1, BSD-3-Clause, approved, #10767
-maven/mavencentral/org.apache.arrow/arrow-format/15.0.0, Apache-2.0, approved, #12854
-maven/mavencentral/org.apache.arrow/arrow-memory-core/15.0.0, Apache-2.0, approved, #12855
-maven/mavencentral/org.apache.arrow/arrow-memory-netty/15.0.0, Apache-2.0, approved, #12853
-maven/mavencentral/org.apache.arrow/arrow-vector/15.0.0, Apache-2.0 AND (Apache-2.0 AND FTL), approved, #12856
 maven/mavencentral/org.apache.commons/commons-compress/1.24.0, Apache-2.0 AND BSD-3-Clause AND bzip2-1.0.6 AND LicenseRef-Public-Domain, approved, #10368
 maven/mavencentral/org.apache.commons/commons-lang3/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.8.1, Apache-2.0, approved, #815
@@ -184,7 +160,6 @@ maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.77, MIT, approved, #11593
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.77, MIT AND CC0-1.0, approved, #11595
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.77, MIT, approved, #11596
-maven/mavencentral/org.checkerframework/checker-compat-qual/2.5.6, GPL-2.0-only with Classpath-Exception-2.0, approved, #11598
 maven/mavencentral/org.checkerframework/checker-qual/3.37.0, MIT, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.41.0, MIT, approved, #12032
 maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, clearlydefined
@@ -195,8 +170,6 @@ maven/mavencentral/org.codehaus.plexus/plexus-container-default/2.1.0, Apache-2.
 maven/mavencentral/org.codehaus.plexus/plexus-utils/3.1.1, , approved, CQ16492
 maven/mavencentral/org.codehaus.plexus/plexus-utils/3.3.0, , approved, CQ21066
 maven/mavencentral/org.conscrypt/conscrypt-openjdk-uber/2.5.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.eclipse.collections/eclipse-collections-api/11.1.0, EPL-1.0 OR BSD-3-Clause, approved, technology.collections
-maven/mavencentral/org.eclipse.collections/eclipse-collections/11.1.0, EPL-1.0 OR BSD-3-Clause, approved, technology.collections
 maven/mavencentral/org.eclipse.edc/autodoc-processor/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/boot/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/catalog-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -286,7 +259,6 @@ maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib/1.9.10, Apache-2.0, approv
 maven/mavencentral/org.jetbrains/annotations/13.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains/annotations/17.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains/annotations/24.1.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.json/json/20231013, OTHER, restricted, clearlydefined
 maven/mavencentral/org.junit-pioneer/junit-pioneer/2.2.0, EPL-2.0, approved, #11857
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.1, EPL-2.0, approved, #9714
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.2, EPL-2.0, approved, #9714
@@ -321,6 +293,5 @@ maven/mavencentral/org.slf4j/slf4j-api/1.7.36, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.7, MIT, approved, #10344
 maven/mavencentral/org.testcontainers/testcontainers/1.19.7, Apache-2.0 AND MIT, approved, #10347
-maven/mavencentral/org.threeten/threeten-extra/1.7.2, BSD-3-Clause, approved, #6493
 maven/mavencentral/org.threeten/threetenbp/1.6.8, BSD-3-Clause, approved, #6750
 maven/mavencentral/org.xmlresolver/xmlresolver/5.2.2, Apache-2.0, approved, clearlydefined

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQueryDataAddress.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQueryDataAddress.java
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.gcp.bigquery;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+
+import java.util.Optional;
+
+import static java.util.Collections.emptyMap;
+
+/**
+ * This is a wrapper class for the {@link DataAddress} object, which has typed accessors for
+ * properties specific to a BigQuery endpoint.
+ */
+@JsonTypeName()
+@JsonDeserialize(builder = DataAddress.Builder.class)
+public class BigQueryDataAddress extends DataAddress {
+    private BigQueryDataAddress() {
+        setType(BigQueryService.BIGQUERY_DATA);
+    }
+
+    @JsonIgnore
+    public String getProject() {
+        return getStringProperty(BigQueryService.PROJECT);
+    }
+
+    @JsonIgnore
+    public String getDataset() {
+        return getStringProperty(BigQueryService.DATASET);
+    }
+
+    @JsonIgnore
+    public String getTable() {
+        return getStringProperty(BigQueryService.TABLE);
+    }
+
+    @JsonIgnore
+    public String getQuery() {
+        return getStringProperty(BigQueryService.QUERY);
+    }
+
+    @JsonIgnore
+    public String getServiceAccountName() {
+        return getStringProperty(BigQueryService.SERVICE_ACCOUNT_NAME);
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder extends DataAddress.Builder<BigQueryDataAddress, Builder> {
+        private Builder() {
+            super(new BigQueryDataAddress());
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder project(String project) {
+            property(BigQueryService.PROJECT, project);
+            return this;
+        }
+
+        public Builder dataset(String dataset) {
+            property(BigQueryService.DATASET, dataset);
+            return this;
+        }
+
+        public Builder table(String table) {
+            property(BigQueryService.TABLE, table);
+            return this;
+        }
+
+        public Builder query(String query) {
+            property(BigQueryService.QUERY, query);
+            return this;
+        }
+
+        public Builder serviceAccountName(String serviceAccountName) {
+            property(BigQueryService.SERVICE_ACCOUNT_NAME, serviceAccountName);
+            return this;
+        }
+
+        @Override
+        public BigQueryDataAddress build() {
+            return address;
+        }
+
+        public Builder copyFrom(DataAddress other) {
+            Optional.ofNullable(other)
+                .map(DataAddress::getProperties)
+                .orElse(emptyMap()).forEach(this::property);
+            return this;
+        }
+    }
+}

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQueryDataAddressValidatorExtension.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQueryDataAddressValidatorExtension.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.gcp.bigquery;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.validator.spi.DataAddressValidatorRegistry;
+
+@Extension(BigQueryDataAddressValidatorExtension.NAME)
+public class BigQueryDataAddressValidatorExtension implements ServiceExtension {
+    public static final String NAME = "BigQuery DataAddress Validator";
+
+    @Inject
+    private DataAddressValidatorRegistry validatorRegistry;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        validatorRegistry.registerDestinationValidator(BigQueryService.BIGQUERY_DATA,
+                new BigQuerySinkDataAddressValidator());
+        validatorRegistry.registerSourceValidator(BigQueryService.BIGQUERY_DATA,
+                new BigQuerySourceDataAddressValidator());
+    }
+}

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQueryPart.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQueryPart.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.gcp.bigquery;
+
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
+
+import java.io.InputStream;
+
+public class BigQueryPart implements DataSource.Part {
+    private final String name;
+    private final InputStream inputStream;
+
+    public BigQueryPart(String name, InputStream inputStream) {
+        this.name = name;
+        this.inputStream = inputStream;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public InputStream openStream() {
+        return inputStream;
+    }
+
+    @Override
+    public long size() {
+        return SIZE_UNKNOWN;
+    }
+}

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQueryService.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQueryService.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.gcp.bigquery;
+
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource.Part;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Interface for BigQuery service.
+ */
+public interface BigQueryService {
+    /** DataAddress type for BigQuery transfer. */
+    String BIGQUERY_DATA = "BigQueryData";
+    /** Project including dataset and table for BigQuery DataAddress, overrides the project defined in connector config. */
+    String PROJECT = "project";
+    /** Dataset including the table for BigQuery DataAddress. */
+    String DATASET = "dataset";
+    /** Table name for the BigQuery DataAddress. */
+    String TABLE = "table";
+    /** Query used to extract data by the BigQuery source. */
+    String QUERY = "query";
+    /** Service account used to access BigQuery service, overrides the service account defined in connector config. */
+    String SERVICE_ACCOUNT_NAME = "service_account_name";
+    /** Customer name used to label the query in the BigQuery source. */
+    String CUSTOMER_NAME = "customer_name";
+
+    /**
+     * Executes the given query and returns the result as stream.
+     *
+     * @param query the query string to be executed.
+     * @param sinkAddress the target address for the sink.
+     *
+     * @return the stream of DataSource.Part objects.
+     */
+    Stream<DataSource.Part> runSourceQuery(String query, DataAddress sinkAddress) throws InterruptedException;
+
+    /**
+     * Executes the given query to insert values into the target table.
+     *
+     * @param parts list of rows to be inserted.
+     */
+    void runSinkQuery(List<Part> parts);
+
+    /**
+     * Checks whether the table defined exists.
+     *
+     * @param target includes the name of the table, within a dataset and a project.
+     * @return true if the table specified exists.
+     */
+    boolean tableExists(BigQueryTarget target);
+}

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQueryServiceImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQueryServiceImpl.java
@@ -191,6 +191,7 @@ public class BigQueryServiceImpl implements BigQueryService {
         }
     }
 
+    @Override
     public Stream<DataSource.Part> runSourceQuery(String query, DataAddress sinkAddress) throws InterruptedException {
         refreshBigQueryCredentials();
 
@@ -239,6 +240,7 @@ public class BigQueryServiceImpl implements BigQueryService {
                 future, new AppendCompleteCallback(), MoreExecutors.directExecutor());
     }
 
+    @Override
     public void runSinkQuery(List<DataSource.Part> parts) {
         if (parts.isEmpty()) {
             return;
@@ -313,6 +315,7 @@ public class BigQueryServiceImpl implements BigQueryService {
         }
     }
 
+    @Override
     public boolean tableExists(BigQueryTarget target) {
         try {
             var table = bigQuery.getTable(target.getTableId());
@@ -383,11 +386,13 @@ public class BigQueryServiceImpl implements BigQueryService {
             inflightRequestCount.register();
         }
 
+        @Override
         public void onSuccess(AppendRowsResponse response) {
             monitor.info("Json writer append success");
             inflightRequestCount.arriveAndDeregister();
         }
 
+        @Override
         public void onFailure(Throwable throwable) {
             monitor.severe("Json writer failed");
             inflightRequestCount.arriveAndDeregister();

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQueryServiceImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQueryServiceImpl.java
@@ -1,0 +1,397 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.gcp.bigquery;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.services.iam.v2.IamScopes;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ImpersonatedCredentials;
+import com.google.auth.oauth2.OAuth2Credentials;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.FieldList;
+import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.JobId;
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
+import com.google.cloud.bigquery.storage.v1.BatchCommitWriteStreamsRequest;
+import com.google.cloud.bigquery.storage.v1.BigQueryWriteClient;
+import com.google.cloud.bigquery.storage.v1.BigQueryWriteSettings;
+import com.google.cloud.bigquery.storage.v1.CreateWriteStreamRequest;
+import com.google.cloud.bigquery.storage.v1.JsonStreamWriter;
+import com.google.cloud.bigquery.storage.v1.WriteStream;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
+import org.eclipse.edc.gcp.common.GcpConfiguration;
+import org.eclipse.edc.gcp.common.GcpException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+public class BigQueryServiceImpl implements BigQueryService {
+    private final GcpConfiguration gcpConfiguration;
+    private final BigQueryTarget target;
+    private final Monitor monitor;
+    private final Phaser inflightRequestCount = new Phaser(1);
+    private BigQuery bigQuery;
+    private BigQueryWriteClient writeClient;
+    private JsonStreamWriter streamWriter;
+    private GoogleCredentials credentials;
+    private String serviceAccountName;
+
+    private BigQueryServiceImpl(GcpConfiguration gcpConfiguration, BigQueryTarget target, Monitor monitor) {
+        this.gcpConfiguration = gcpConfiguration;
+        this.target = target;
+        this.monitor = monitor;
+    }
+
+    private void initCredentials() throws IOException {
+        var project = target.project();
+        if (project == null) {
+            project = gcpConfiguration.getProjectId();
+        }
+
+        if (credentials != null) {
+            monitor.info("BigQuery extension for project '" + project + "' using provided credentials");
+            return;
+        }
+
+        var sourceCredentials = GoogleCredentials.getApplicationDefault()
+                .createScoped(IamScopes.CLOUD_PLATFORM);
+        sourceCredentials.refreshIfExpired();
+
+        if (serviceAccountName == null) {
+            monitor.info("BigQuery extension for project '" + project + "' using ADC, NOT RECOMMENDED");
+            credentials = sourceCredentials;
+            return;
+        }
+
+        monitor.info("BigQuery extension for project '" + project + "' using service account '" + serviceAccountName + "'");
+        credentials = ImpersonatedCredentials.create(
+                sourceCredentials,
+                serviceAccountName,
+                null,
+                Arrays.asList("https://www.googleapis.com/auth/bigquery"),
+                300);
+    }
+
+    private void checkStreamWriter()
+        throws DescriptorValidationException, IOException, InterruptedException {
+        monitor.info("BigQuery creating stream writer in pending mode for table " + target.getTableName().toString());
+        if (streamWriter == null) {
+            var stream = WriteStream.newBuilder().setType(WriteStream.Type.PENDING).build();
+
+            var createWriteStreamRequest =
+                    CreateWriteStreamRequest.newBuilder()
+                    .setParent(target.getTableName().toString())
+                    .setWriteStream(stream)
+                    .build();
+            var writeStream = writeClient.createWriteStream(createWriteStreamRequest);
+
+            var builder = JsonStreamWriter.newBuilder(writeStream.getName(), writeClient);
+            if (credentials != null) {
+                builder.setCredentialsProvider(FixedCredentialsProvider.create(credentials));
+            }
+
+            streamWriter = builder.build();
+        }
+
+        if (streamWriter.isClosed()) {
+            // TODO re-create the writer for a maximum, specified number of times.
+            monitor.info("BigQuery stream writer closed, recreating it for stream " + streamWriter.getStreamName());
+            var builder = JsonStreamWriter.newBuilder(streamWriter.getStreamName(), writeClient);
+            if (credentials != null) {
+                builder.setCredentialsProvider(FixedCredentialsProvider.create(credentials));
+            }
+            streamWriter = builder.build();
+        }
+    }
+
+    private void initService() throws IOException {
+        if (bigQuery != null && writeClient != null) {
+            return;
+        }
+
+        initCredentials();
+
+        var project = target.project();
+        if (project == null) {
+            project = gcpConfiguration.getProjectId();
+        }
+
+        var bqBuilder = BigQueryOptions.newBuilder().setProjectId(project);
+
+        if (credentials != null) {
+            bqBuilder.setCredentials(credentials);
+        }
+
+        bigQuery = bqBuilder.build().getService();
+
+        var settingsBuilder = BigQueryWriteSettings.newBuilder();
+        if (credentials != null) {
+            settingsBuilder.setCredentialsProvider(FixedCredentialsProvider.create(credentials));
+        }
+
+        writeClient = BigQueryWriteClient.create(settingsBuilder.build());
+    }
+
+    private JSONObject buildRecord(FieldList fields, FieldValueList values) {
+        var record = new JSONObject();
+        int colCount = fields.size();
+        for (int i = 0; i < colCount; i++) {
+            record.put(fields.get(i).getName(), values.get(i).getValue());
+        }
+
+        return record;
+    }
+
+    private void refreshBigQueryCredentials() {
+        var credentials = bigQuery.getOptions().getCredentials();
+        if (!(credentials instanceof OAuth2Credentials)) {
+            return;
+        }
+
+        try {
+            // TODO check margin and refresh if too close to expire.
+            ((OAuth2Credentials) credentials).refreshIfExpired();
+        } catch (IOException ioException) {
+            monitor.warning("Cannot refresh BigQuery credentials", ioException);
+        }
+    }
+
+    public Stream<DataSource.Part> runSourceQuery(String query, DataAddress sinkAddress) throws InterruptedException {
+        refreshBigQueryCredentials();
+
+        var queryConfigBuilder = QueryJobConfiguration.newBuilder(query);
+        var customerName = sinkAddress.getStringProperty(CUSTOMER_NAME);
+        if (customerName != null) {
+            queryConfigBuilder.setLabels(ImmutableMap.of("customer", customerName));
+        }
+
+        // Use standard SQL syntax for queries.
+        // See: https://cloud.google.com/bigquery/sql-reference/
+        var queryConfig = queryConfigBuilder
+                .setUseLegacySql(false)
+                .build();
+
+        var jobId = JobId.of(UUID.randomUUID().toString());
+        var queryJob = bigQuery.create(JobInfo.newBuilder(queryConfig).setJobId(jobId).build());
+
+        queryJob = queryJob.waitFor();
+
+        if (queryJob == null) {
+            throw new GcpException("Job no longer exists");
+        } else if (queryJob.getStatus().getError() != null) {
+            // Another way is invoking queryJob.getStatus().getExecutionErrors()
+            // to get all errors.
+            throw new GcpException(queryJob.getStatus().getError().toString());
+        }
+
+        var schema = queryJob.getQueryResults().getSchema();
+        var partArray = new JSONArray();
+        var parts = new ArrayList<DataSource.Part>();
+        for (FieldValueList row : queryJob.getQueryResults().iterateAll()) {
+            partArray.put(buildRecord(schema.getFields(), row));
+        }
+        parts.add(new BigQueryPart("allRows", new ByteArrayInputStream(
+                partArray.toString().getBytes())));
+
+        return parts.stream();
+    }
+
+    private void append(JSONArray data)
+        throws DescriptorValidationException, IOException, InterruptedException {
+        checkStreamWriter();
+        ApiFuture<AppendRowsResponse> future = streamWriter.append(data);
+        ApiFutures.addCallback(
+                future, new AppendCompleteCallback(), MoreExecutors.directExecutor());
+    }
+
+    public void runSinkQuery(List<DataSource.Part> parts) {
+        if (parts.isEmpty()) {
+            return;
+        }
+
+        var errorWhileAppending = false;
+        for (var part : parts) {
+            try (var inputStream = part.openStream()) {
+                var text = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+                // TODO re-try the append operation for a maximum, specified number of times.
+                append(new JSONArray(text));
+            } catch (IOException ioException) {
+                errorWhileAppending = true;
+                monitor.severe("BigQuery error while appending", ioException);
+                break;
+            } catch (InterruptedException interruptedException) {
+                errorWhileAppending = true;
+                monitor.severe("BigQuery error while appending", interruptedException);
+                break;
+            } catch (DescriptorValidationException descriptorValidationException) {
+                errorWhileAppending = true;
+                monitor.severe("BigQuery error while appending", descriptorValidationException);
+                break;
+            }
+        }
+
+        inflightRequestCount.arriveAndAwaitAdvance();
+        streamWriter.close();
+
+        monitor.info("BigQuery requests arrived, stream " + streamWriter.getStreamName() + " for table " + target.getTableName().toString() + " closed, now finalizing..");
+        var finalizeResponse =
+                writeClient.finalizeWriteStream(streamWriter.getStreamName());
+        monitor.info("BigQuery rows written: " + finalizeResponse.getRowCount());
+
+        if (!errorWhileAppending) {
+            var commitRequest =
+                    BatchCommitWriteStreamsRequest.newBuilder()
+                    .setParent(target.getTableName().toString())
+                    .addWriteStreams(streamWriter.getStreamName())
+                    .build();
+            var commitResponse = writeClient.batchCommitWriteStreams(commitRequest);
+
+            if (!commitResponse.hasCommitTime()) {
+                var errorLogged = false;
+                for (var err : commitResponse.getStreamErrorsList()) {
+                    errorLogged = true;
+                    monitor.severe("BigQuery error while committing the streams " + err.getErrorMessage());
+                }
+                if (!errorLogged) {
+                    monitor.severe("BigQuery error while committing the streams");
+                }
+            } else {
+                monitor.info("BigQuery records committed successfully, write client shutting down...");
+            }
+        }
+        writeClient.shutdownNow();
+        var waitIterationCount = 0;
+        var terminated = false;
+        do {
+            try {
+                terminated = writeClient.awaitTermination(2, TimeUnit.SECONDS);
+            } catch (InterruptedException interruptedException) {
+                monitor.info("BigQuery write client shut down (interrupted)");
+            }
+            waitIterationCount++;
+        } while (!terminated && waitIterationCount < 3);
+
+        if (terminated) {
+            monitor.info("BigQuery write client shut down");
+        } else {
+            monitor.warning("BigQuery write client NOT shut down after timeout");
+        }
+    }
+
+    public boolean tableExists(BigQueryTarget target) {
+        try {
+            var table = bigQuery.getTable(target.getTableId());
+            if (table != null && table.exists()) {
+                return true;
+            }
+
+            return false;
+        } catch (BigQueryException bigQueryException) {
+            monitor.debug(bigQueryException.toString());
+            return false;
+        }
+    }
+
+    public static class Builder {
+        private final BigQueryServiceImpl bqService;
+
+        public static Builder newInstance(GcpConfiguration gcpConfiguration, BigQueryTarget target, Monitor monitor) {
+            return new Builder(gcpConfiguration, target, monitor);
+        }
+
+        private Builder(GcpConfiguration gcpConfiguration, BigQueryTarget target, Monitor monitor) {
+            bqService = new BigQueryServiceImpl(gcpConfiguration, target, monitor);
+        }
+
+        public Builder credentials(GoogleCredentials credentials) {
+            bqService.credentials = credentials;
+            return this;
+        }
+
+        public Builder serviceAccount(String serviceAccountName) {
+            bqService.serviceAccountName = serviceAccountName;
+            return this;
+        }
+
+        Builder bigQuery(BigQuery bigQuery) {
+            bqService.bigQuery = bigQuery;
+            return this;
+        }
+
+        Builder writeClient(BigQueryWriteClient writeClient) {
+            bqService.writeClient = writeClient;
+            return this;
+        }
+
+        Builder streamWriter(JsonStreamWriter streamWriter) {
+            bqService.streamWriter = streamWriter;
+            return this;
+        }
+
+        public BigQueryServiceImpl build() {
+            try {
+                bqService.initService();
+                Objects.requireNonNull(bqService.bigQuery, "bigQuery");
+                return bqService;
+            } catch (IOException ioException) {
+                throw new GcpException(ioException);
+            }
+        }
+    }
+
+    void testAppendSignal() {
+        inflightRequestCount.arriveAndDeregister();
+    }
+
+    private class AppendCompleteCallback implements ApiFutureCallback<AppendRowsResponse> {
+        AppendCompleteCallback() {
+            inflightRequestCount.register();
+        }
+
+        public void onSuccess(AppendRowsResponse response) {
+            monitor.info("Json writer append success");
+            inflightRequestCount.arriveAndDeregister();
+        }
+
+        public void onFailure(Throwable throwable) {
+            monitor.severe("Json writer failed");
+            inflightRequestCount.arriveAndDeregister();
+            // TODO retry the append operation for a maximum, specified number of times.
+        }
+    }
+}

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQueryServiceImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQueryServiceImpl.java
@@ -581,7 +581,7 @@ public class BigQueryServiceImpl implements BigQueryService {
 
         String getString2() {
             if (readOffset <= writeOffset) {
-                return new String("");
+                return "";
             }
 
             return new String(buffer, 0, writeOffset);

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQuerySinkDataAddressValidator.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQuerySinkDataAddressValidator.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.gcp.bigquery;
+
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.util.string.StringUtils;
+import org.eclipse.edc.validator.spi.ValidationResult;
+import org.eclipse.edc.validator.spi.Validator;
+import org.eclipse.edc.validator.spi.Violation;
+
+import java.util.ArrayList;
+
+import static org.eclipse.edc.gcp.bigquery.BigQueryService.DATASET;
+import static org.eclipse.edc.gcp.bigquery.BigQueryService.TABLE;
+import static org.eclipse.edc.validator.spi.ValidationResult.failure;
+import static org.eclipse.edc.validator.spi.ValidationResult.success;
+
+public class BigQuerySinkDataAddressValidator implements Validator<DataAddress> {
+    @Override
+    public ValidationResult validate(DataAddress input) {
+        var violations = new ArrayList<Violation>();
+
+        if (StringUtils.isNullOrBlank(input.getStringProperty(TABLE, null))) {
+            violations.add(Violation.violation("Must have a %s property".formatted(TABLE), TABLE));
+        }
+
+        if (StringUtils.isNullOrBlank(input.getStringProperty(DATASET, null))) {
+            violations.add(Violation.violation("Must have a %s property".formatted(DATASET), DATASET));
+        }
+
+        if (!violations.isEmpty()) {
+            return failure(violations);
+        }
+        return success();
+    }
+}

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQuerySourceDataAddressValidator.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQuerySourceDataAddressValidator.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.gcp.bigquery;
+
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.util.string.StringUtils;
+import org.eclipse.edc.validator.spi.ValidationResult;
+import org.eclipse.edc.validator.spi.Validator;
+import org.eclipse.edc.validator.spi.Violation;
+
+import java.util.ArrayList;
+
+import static org.eclipse.edc.gcp.bigquery.BigQueryService.QUERY;
+import static org.eclipse.edc.validator.spi.ValidationResult.failure;
+import static org.eclipse.edc.validator.spi.ValidationResult.success;
+
+public class BigQuerySourceDataAddressValidator implements Validator<DataAddress> {
+    @Override
+    public ValidationResult validate(DataAddress input) {
+        var violations = new ArrayList<Violation>();
+
+        if (StringUtils.isNullOrBlank(input.getStringProperty(QUERY, null))) {
+            violations.add(Violation.violation("Must have a %s property".formatted(QUERY), QUERY));
+        }
+
+        if (!violations.isEmpty()) {
+            return failure(violations);
+        }
+        return success();
+    }
+}

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQueryTarget.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/BigQueryTarget.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.gcp.bigquery;
+
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.storage.v1.TableName;
+
+public record BigQueryTarget(String project, String dataset, String table) {
+    public TableId getTableId() {
+        return TableId.of(project, dataset, table);
+    }
+
+    public TableName getTableName() {
+        return TableName.of(project, dataset, table);
+    }
+}

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpAccessToken.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpAccessToken.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpConfiguration.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpConfiguration.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpException.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpException.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpExtension.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpExtension.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpServiceAccount.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpServiceAccount.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcsBucket.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcsBucket.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/AccessTokenProvider.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/AccessTokenProvider.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamService.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamService.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/GcsStoreSchema.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/GcsStoreSchema.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/StorageService.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/StorageService.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/StorageServiceImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/StorageServiceImpl.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/bigquery/Asserts.java
+++ b/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/bigquery/Asserts.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.gcp.bigquery;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource.Part;
+
+public class Asserts extends Assertions {
+
+    private Asserts() {}
+
+    public static PartAssert assertThat(Part actual) {
+        return new PartAssert(actual);
+    }
+
+    public static BigQueryPartAssert assertThat(BigQueryPart actual) {
+        return new BigQueryPartAssert(actual);
+    }
+}

--- a/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/bigquery/BigQueryDataAddressValidatorExtensionTest.java
+++ b/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/bigquery/BigQueryDataAddressValidatorExtensionTest.java
@@ -16,9 +16,7 @@ package org.eclipse.edc.gcp.bigquery;
 
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-// import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.validator.spi.DataAddressValidatorRegistry;
-// import org.eclipse.edc.validator.spi.ValidationResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -54,52 +52,4 @@ public class BigQueryDataAddressValidatorExtensionTest {
         verify(registry).registerDestinationValidator(eq(BigQueryService.BIGQUERY_DATA), isA(BigQuerySinkDataAddressValidator.class));
         verify(registry).registerSourceValidator(eq(BigQueryService.BIGQUERY_DATA), isA(BigQuerySourceDataAddressValidator.class));
     }
-
-    /*
-    @Test
-    void testExtensionShouldValidateWellFormedAddresses(BigQueryDataAddressValidatorExtension extension, ServiceExtensionContext context) {
-        extension.initialize(context);
-
-        var validSourceAddress = DataAddress.Builder.newInstance()
-                .type(BigQueryService.BIGQUERY_DATA)
-                .property(BigQueryService.QUERY, TEST_QUERY)
-                .build();
-
-        // assertThat(registry.validateSource(validSourceAddress)).isEqualTo(ValidationResult.success());
-
-        var validSinkAddress = DataAddress.Builder.newInstance()
-                .type(BigQueryService.BIGQUERY_DATA)
-                .property(BigQueryService.DATASET, TEST_DATASET)
-                .property(BigQueryService.TABLE, TEST_TABLE)
-                .build();
-
-        assertThat(registry.validateDestination(validSinkAddress)).isEqualTo(ValidationResult.success());
-    }
-
-    @Test
-    void testExtensionShouldNotValidateIncompleteAddresses(BigQueryDataAddressValidatorExtension extension, ServiceExtensionContext context) {
-        extension.initialize(context);
-
-        var invalidSourceAddressNoQuery = DataAddress.Builder.newInstance()
-                .type(BigQueryService.BIGQUERY_DATA)
-                .property(BigQueryService.TABLE, TEST_TABLE)
-                .build();
-
-        assertThat(registry.validateSource(invalidSourceAddressNoQuery)).isNotEqualTo(ValidationResult.success());
-
-        var invalidSinkAddressNoTable = DataAddress.Builder.newInstance()
-                .type(BigQueryService.BIGQUERY_DATA)
-                .property(BigQueryService.DATASET, TEST_DATASET)
-                .build();
-
-        assertThat(registry.validateDestination(invalidSinkAddressNoTable)).isNotEqualTo(ValidationResult.success());
-
-        var invalidSinkAddressNoDataset = DataAddress.Builder.newInstance()
-                .type(BigQueryService.BIGQUERY_DATA)
-                .property(BigQueryService.TABLE, TEST_TABLE)
-                .build();
-
-        assertThat(registry.validateDestination(invalidSinkAddressNoDataset)).isNotEqualTo(ValidationResult.success());
-    }
-    */
 }

--- a/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/bigquery/BigQueryDataAddressValidatorExtensionTest.java
+++ b/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/bigquery/BigQueryDataAddressValidatorExtensionTest.java
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.gcp.bigquery;
+
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+// import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.validator.spi.DataAddressValidatorRegistry;
+// import org.eclipse.edc.validator.spi.ValidationResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(DependencyInjectionExtension.class)
+public class BigQueryDataAddressValidatorExtensionTest {
+    private static final String TEST_PROJECT = "test-project";
+    private static final String TEST_DATASET = "test-dataset";
+    private static final String TEST_TABLE = "test-table";
+    private static final String TEST_QUERY = "SELECT * from " + TEST_TABLE;
+    private static final String TEST_OTHER_TYPE = "AnotherDataAddressType";
+    private static final String TEST_CUSTOMER_NAME = "customer-name";
+    private static final String TEST_SINK_SERVICE_ACCOUNT_NAME = "sinkAccount";
+    private final DataAddressValidatorRegistry registry = mock();
+
+    @BeforeEach
+    void setupContext(ServiceExtensionContext context) {
+        context.registerService(DataAddressValidatorRegistry.class, registry);
+    }
+
+    @Test
+    void testInitializeShouldRegisterValidators(BigQueryDataAddressValidatorExtension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        assertThat(extension.name()).isEqualTo(BigQueryDataAddressValidatorExtension.NAME);
+
+        verify(registry).registerDestinationValidator(eq(BigQueryService.BIGQUERY_DATA), isA(BigQuerySinkDataAddressValidator.class));
+        verify(registry).registerSourceValidator(eq(BigQueryService.BIGQUERY_DATA), isA(BigQuerySourceDataAddressValidator.class));
+    }
+
+    /*
+    @Test
+    void testExtensionShouldValidateWellFormedAddresses(BigQueryDataAddressValidatorExtension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        var validSourceAddress = DataAddress.Builder.newInstance()
+                .type(BigQueryService.BIGQUERY_DATA)
+                .property(BigQueryService.QUERY, TEST_QUERY)
+                .build();
+
+        // assertThat(registry.validateSource(validSourceAddress)).isEqualTo(ValidationResult.success());
+
+        var validSinkAddress = DataAddress.Builder.newInstance()
+                .type(BigQueryService.BIGQUERY_DATA)
+                .property(BigQueryService.DATASET, TEST_DATASET)
+                .property(BigQueryService.TABLE, TEST_TABLE)
+                .build();
+
+        assertThat(registry.validateDestination(validSinkAddress)).isEqualTo(ValidationResult.success());
+    }
+
+    @Test
+    void testExtensionShouldNotValidateIncompleteAddresses(BigQueryDataAddressValidatorExtension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        var invalidSourceAddressNoQuery = DataAddress.Builder.newInstance()
+                .type(BigQueryService.BIGQUERY_DATA)
+                .property(BigQueryService.TABLE, TEST_TABLE)
+                .build();
+
+        assertThat(registry.validateSource(invalidSourceAddressNoQuery)).isNotEqualTo(ValidationResult.success());
+
+        var invalidSinkAddressNoTable = DataAddress.Builder.newInstance()
+                .type(BigQueryService.BIGQUERY_DATA)
+                .property(BigQueryService.DATASET, TEST_DATASET)
+                .build();
+
+        assertThat(registry.validateDestination(invalidSinkAddressNoTable)).isNotEqualTo(ValidationResult.success());
+
+        var invalidSinkAddressNoDataset = DataAddress.Builder.newInstance()
+                .type(BigQueryService.BIGQUERY_DATA)
+                .property(BigQueryService.TABLE, TEST_TABLE)
+                .build();
+
+        assertThat(registry.validateDestination(invalidSinkAddressNoDataset)).isNotEqualTo(ValidationResult.success());
+    }
+    */
+}

--- a/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/bigquery/BigQueryPartAssert.java
+++ b/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/bigquery/BigQueryPartAssert.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.gcp.bigquery;
+
+import org.assertj.core.api.AbstractAssert;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BigQueryPartAssert extends AbstractAssert<BigQueryPartAssert, BigQueryPart> {
+    public BigQueryPartAssert(BigQueryPart actual) {
+        super(actual, BigQueryPartAssert.class);
+    }
+
+    public BigQueryPartAssert isEqualTo(BigQueryPart expected) {
+        isNotNull();
+        assertThat(actual.name()).isEqualTo(expected.name());
+
+        try {
+            var actualPayload = new String(actual.openStream().readAllBytes(),
+                    StandardCharsets.UTF_8);
+            var expectedPayload = new String(expected.openStream().readAllBytes(),
+                    StandardCharsets.UTF_8);
+
+            assertThat(actualPayload).isEqualTo(expectedPayload);
+        } catch (IOException ioException) {
+            failWithMessage(ioException.getMessage());
+        }
+
+        return this;
+    }
+}

--- a/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/bigquery/BigQueryServiceImplTest.java
+++ b/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/bigquery/BigQueryServiceImplTest.java
@@ -1,0 +1,266 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.gcp.bigquery;
+
+import com.google.api.core.ApiFuture;
+import com.google.auth.oauth2.OAuth2Credentials;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.FieldList;
+import com.google.cloud.bigquery.FieldValue;
+import com.google.cloud.bigquery.FieldValue.Attribute;
+import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.JobStatus;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableResult;
+import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
+import com.google.cloud.bigquery.storage.v1.BatchCommitWriteStreamsRequest;
+import com.google.cloud.bigquery.storage.v1.BatchCommitWriteStreamsResponse;
+import com.google.cloud.bigquery.storage.v1.BigQueryWriteClient;
+import com.google.cloud.bigquery.storage.v1.FinalizeWriteStreamResponse;
+import com.google.cloud.bigquery.storage.v1.JsonStreamWriter;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource.Part;
+import org.eclipse.edc.gcp.common.GcpConfiguration;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.eclipse.edc.gcp.bigquery.Asserts.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BigQueryServiceImplTest {
+    private static final String TEST_PROJECT = "test-project";
+    private static final String TEST_DATASET = "test-dataset";
+    private static final String TEST_TABLE = "test-table";
+    private static final String TEST_QUERY = "select * from " + TEST_TABLE;
+    private static final String TEST_CUSTOMER_NAME = "customer_name";
+    private static final List<Field> TEST_FIELDS = Arrays.asList(
+            Field.of("textfield", LegacySQLTypeName.STRING),
+            Field.of("integerfield", LegacySQLTypeName.INTEGER),
+            Field.of("booleanfield", LegacySQLTypeName.BOOLEAN)
+    );
+    private static final List<FieldValue> TEST_ROW_1 = Arrays.asList(
+            FieldValue.of(Attribute.PRIMITIVE, "row1 textvalue"),
+            FieldValue.of(Attribute.PRIMITIVE, "1"),
+            FieldValue.of(Attribute.PRIMITIVE, "false")
+    );
+    private static final List<FieldValue> TEST_ROW_2 = Arrays.asList(
+            FieldValue.of(Attribute.PRIMITIVE, "row2 textvalue"),
+            FieldValue.of(Attribute.PRIMITIVE, "-4"),
+            FieldValue.of(Attribute.PRIMITIVE, "true")
+    );
+    private final BigQueryTarget target = new BigQueryTarget(TEST_PROJECT, TEST_DATASET, TEST_TABLE);
+    private BigQueryServiceImpl bigQueryService;
+    private Monitor monitor = mock();
+    private GcpConfiguration gcpConfiguration = mock();
+    private BigQuery bigQuery = mock();
+    private BigQueryWriteClient writeClient = mock();
+    private Table table = mock();
+    private TypeManager typeManager = mock();
+    private JsonStreamWriter streamWriter = mock();
+
+    @BeforeEach
+    void setUp() {
+        reset(gcpConfiguration);
+        reset(monitor);
+        reset(bigQuery);
+        reset(writeClient);
+        reset(table);
+        reset(typeManager);
+        reset(streamWriter);
+
+        bigQueryService = BigQueryServiceImpl.Builder.newInstance(gcpConfiguration, target, monitor)
+            .bigQuery(bigQuery)
+            .writeClient(writeClient)
+            .streamWriter(streamWriter)
+            .build();
+    }
+
+    @Test
+    void testTableExistsTrue() {
+        when(table.exists()).thenReturn(true);
+        when(bigQuery.getTable(target.getTableId())).thenReturn(table);
+
+        assertThat(bigQueryService.tableExists(target)).isTrue();
+    }
+
+    @Test
+    void testTableExistsFalse() {
+        when(table.exists()).thenReturn(false);
+        when(bigQuery.getTable(target.getTableId())).thenReturn(table);
+
+        assertThat(bigQueryService.tableExists(target)).isFalse();
+    }
+
+    private void testRunSinkQuery(boolean succeeds) throws DescriptorValidationException, IOException, InterruptedException, ExecutionException, TimeoutException {
+        var parts = new ArrayList<Part>();
+        parts.add(getPart(TEST_FIELDS, Arrays.asList(TEST_ROW_1, TEST_ROW_2)));
+        var partsCount = parts.stream().mapToLong(o -> o.size()).sum();
+
+        if (succeeds) {
+            ApiFuture<AppendRowsResponse> future = mock();
+            AppendRowsResponse response = mock();
+            when(future.isDone()).thenReturn(true);
+            when(future.cancel(anyBoolean())).thenReturn(false);
+            when(future.isCancelled()).thenReturn(false);
+            doNothing().when(future).addListener(any(Runnable.class), any(Executor.class));
+            when(future.get()).thenReturn(response);
+            when(future.get(anyLong(), any())).thenReturn(response);
+            when(streamWriter.append(any())).thenReturn(future);
+        } else {
+            when(streamWriter.append(any())).thenThrow(new IOException());
+        }
+        when(streamWriter.isClosed()).thenReturn(false);
+        when(streamWriter.getStreamName()).thenReturn("name");
+        when(writeClient.finalizeWriteStream(streamWriter.getStreamName())).thenReturn(
+                FinalizeWriteStreamResponse.newBuilder().setRowCount(partsCount).build());
+
+        var commitResponse = mock(BatchCommitWriteStreamsResponse.class);
+        when(commitResponse.hasCommitTime()).thenReturn(true);
+        when(commitResponse.getStreamErrorsList()).thenReturn(Arrays.asList());
+        when(writeClient.batchCommitWriteStreams(any(BatchCommitWriteStreamsRequest.class))).thenReturn(commitResponse);
+
+        var executorService = Executors.newSingleThreadScheduledExecutor();
+        executorService.schedule(() -> bigQueryService.testAppendSignal(), 2, TimeUnit.SECONDS);
+
+        bigQueryService.runSinkQuery(parts);
+
+        verify(streamWriter, times(parts.size())).append(any());
+        verify(streamWriter).close();
+        verify(writeClient).finalizeWriteStream("name");
+        if (succeeds) {
+            verify(writeClient).batchCommitWriteStreams(any(BatchCommitWriteStreamsRequest.class));
+        } else {
+            // If an error occurred while appending rows, then data should not be committed.
+            verify(writeClient, never()).batchCommitWriteStreams(any(BatchCommitWriteStreamsRequest.class));
+        }
+    }
+
+    @Test
+    void testRunSinkQuerySucceeds() throws DescriptorValidationException, IOException, InterruptedException, ExecutionException, TimeoutException {
+        testRunSinkQuery(true);
+    }
+
+    @Test
+    void testRunSinkQueryFailsNoCommit() throws DescriptorValidationException, IOException, InterruptedException, ExecutionException, TimeoutException {
+        testRunSinkQuery(false);
+    }
+
+    private void testRunSourceQuery(String sinkType) throws InterruptedException, IOException {
+        var sinkAddress = DataAddress.Builder.newInstance()
+                .type(sinkType)
+                .property("customerName", TEST_CUSTOMER_NAME)
+                .build();
+
+        var queryJob = mock(Job.class);
+        var tableResult = mock(TableResult.class);
+        var schema = mock(Schema.class);
+        var jobStatus = mock(JobStatus.class);
+
+        when(bigQuery.create(any(JobInfo.class))).thenReturn(queryJob);
+
+        when(queryJob.getQueryResults()).thenReturn(tableResult);
+        when(tableResult.getSchema()).thenReturn(schema);
+        when(schema.getFields()).thenReturn(FieldList.of(TEST_FIELDS));
+        when(tableResult.iterateAll()).thenReturn(Arrays.asList(
+                FieldValueList.of(TEST_ROW_1),
+                FieldValueList.of(TEST_ROW_2)
+        ));
+
+        var options = mock(BigQueryOptions.class);
+        when(bigQuery.getOptions()).thenReturn(options);
+
+        var credentials = mock(OAuth2Credentials.class);
+        when(options.getCredentials()).thenReturn(credentials);
+        when(credentials.getAccessToken()).thenReturn(null);
+
+        when(queryJob.waitFor()).thenReturn(queryJob);
+        when(queryJob.getStatus()).thenReturn(jobStatus);
+        when(jobStatus.getError()).thenReturn(null);
+
+        var receivedParts = bigQueryService.runSourceQuery(TEST_QUERY, sinkAddress);
+
+        verify(credentials).refreshIfExpired();
+        verify(bigQuery).create(any(JobInfo.class));
+        verify(queryJob).waitFor();
+
+        var rows = Arrays.asList(TEST_ROW_1, TEST_ROW_2);
+        var expectedParts = Arrays.asList(getPart(TEST_FIELDS, rows));
+
+        var receivedList = receivedParts.toList();
+        assertThat(receivedList.size()).isEqualTo(expectedParts.size());
+        for (int i = 0; i < receivedList.size(); i++) {
+            assertThat(receivedList.get(i)).isEqualTo(expectedParts.get(i));
+        }
+    }
+
+    @Test
+    void testRunSourceQueryWithBigQuerySink() throws InterruptedException, IOException {
+        testRunSourceQuery("BigQueryData");
+    }
+
+    @Test
+    void testRunSourceQueryWithStandardSink() throws InterruptedException, IOException {
+        testRunSourceQuery("StandardSink");
+    }
+
+    private JSONObject buildRecord(List<Field> fields, List<FieldValue> values) {
+        var record = new JSONObject();
+        for (int i = 0; i < fields.size(); i++) {
+            record.put(fields.get(i).getName(), values.get(i).getValue());
+        }
+
+        return record;
+    }
+
+    private BigQueryPart getPart(List<Field> fieldList, List<List<FieldValue>> fieldValueLists) {
+        var array = new JSONArray();
+        for (var row : fieldValueLists) {
+            array.put(buildRecord(fieldList, row));
+        }
+        return new BigQueryPart("allRows", new ByteArrayInputStream(
+            array.toString().getBytes()));
+    }
+}

--- a/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/bigquery/BigQuerySinkDataAddressValidatorTest.java
+++ b/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/bigquery/BigQuerySinkDataAddressValidatorTest.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.gcp.bigquery;
+
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BigQuerySinkDataAddressValidatorTest {
+    private static final String TEST_DATASET = "test-dataset";
+    private static final String TEST_TABLE = "test-table";
+    private final BigQuerySinkDataAddressValidator validator = new BigQuerySinkDataAddressValidator();
+
+    @Test
+    void testSinkValidatorShouldValidateWellFormedAddresses() {
+        var validSinkAddress = DataAddress.Builder.newInstance()
+                .type(BigQueryService.BIGQUERY_DATA)
+                .property(BigQueryService.DATASET, TEST_DATASET)
+                .property(BigQueryService.TABLE, TEST_TABLE)
+                .build();
+
+        var validationResult = validator.validate(validSinkAddress);
+        assertThat(validationResult.succeeded()).isTrue();
+    }
+
+    @Test
+    void testSinkValidatorShouldNotValidateIncompleteAddresses() {
+        var invalidSinkAddressNoTable = DataAddress.Builder.newInstance()
+                .type(BigQueryService.BIGQUERY_DATA)
+                .property(BigQueryService.DATASET, TEST_DATASET)
+                .build();
+
+        assertThat(validator.validate(invalidSinkAddressNoTable).failed()).isTrue();
+
+        var invalidSinkAddressNoDataset = DataAddress.Builder.newInstance()
+                .type(BigQueryService.BIGQUERY_DATA)
+                .property(BigQueryService.TABLE, TEST_TABLE)
+                .build();
+
+        assertThat(validator.validate(invalidSinkAddressNoDataset).failed()).isTrue();
+
+        var invalidSinkAddressNoInfo = DataAddress.Builder.newInstance()
+                .type(BigQueryService.BIGQUERY_DATA)
+                .build();
+
+        assertThat(validator.validate(invalidSinkAddressNoInfo).failed()).isTrue();
+    }
+}

--- a/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/bigquery/BigQuerySourceDataAddressValidatorTest.java
+++ b/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/bigquery/BigQuerySourceDataAddressValidatorTest.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.gcp.bigquery;
+
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BigQuerySourceDataAddressValidatorTest {
+    private static final String TEST_TABLE = "test-table";
+    private static final String TEST_QUERY = "SELECT * from " + TEST_TABLE;
+    private final BigQuerySourceDataAddressValidator validator = new BigQuerySourceDataAddressValidator();
+
+    @Test
+    void testSinkValidatorShouldValidateWellFormedAddresses() {
+        var validSourceAddress = DataAddress.Builder.newInstance()
+                .type(BigQueryService.BIGQUERY_DATA)
+                .property(BigQueryService.QUERY, TEST_QUERY)
+                .build();
+
+        var validationResult = validator.validate(validSourceAddress);
+        assertThat(validationResult.succeeded()).isTrue();
+    }
+
+    @Test
+    void testSinkValidatorShouldNotValidateIncompleteAddresses() {
+        var invalidSourceAddressNoQuery = DataAddress.Builder.newInstance()
+                .type(BigQueryService.BIGQUERY_DATA)
+                .property(BigQueryService.TABLE, TEST_TABLE)
+                .build();
+
+        assertThat(validator.validate(invalidSourceAddressNoQuery).failed()).isTrue();
+    }
+}

--- a/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/bigquery/PartAssert.java
+++ b/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/bigquery/PartAssert.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.gcp.bigquery;
+
+import org.assertj.core.api.AbstractAssert;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource.Part;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PartAssert extends AbstractAssert<PartAssert, Part> {
+    public PartAssert(Part actual) {
+        super(actual, PartAssert.class);
+    }
+
+    public PartAssert isEqualTo(Part expected) {
+        isNotNull();
+        assertThat(actual.name()).isEqualTo(expected.name());
+
+        try {
+            var actualPayload = new String(actual.openStream().readAllBytes(),
+                    StandardCharsets.UTF_8);
+            var expectedPayload = new String(expected.openStream().readAllBytes(),
+                    StandardCharsets.UTF_8);
+
+            assertThat(actualPayload).isEqualTo(expectedPayload);
+        } catch (IOException ioException) {
+            failWithMessage(ioException.getMessage());
+        }
+
+        return this;
+    }
+}

--- a/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/iam/IamServiceImplTest.java
+++ b/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/iam/IamServiceImplTest.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/storage/StorageServiceImplTest.java
+++ b/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/storage/StorageServiceImplTest.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/common/vault/vault-gcp/src/main/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVault.java
+++ b/extensions/common/vault/vault-gcp/src/main/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVault.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/common/vault/vault-gcp/src/main/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVaultExtension.java
+++ b/extensions/common/vault/vault-gcp/src/main/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVaultExtension.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/common/vault/vault-gcp/src/test/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVaultExtensionTest.java
+++ b/extensions/common/vault/vault-gcp/src/test/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVaultExtensionTest.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/common/vault/vault-gcp/src/test/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVaultTest.java
+++ b/extensions/common/vault/vault-gcp/src/test/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVaultTest.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/control-plane/provision/provision-bigquery/build.gradle.kts
+++ b/extensions/control-plane/provision/provision-bigquery/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Google LLC
+ *  Copyright (c) 2024 Google LLC
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -18,21 +18,14 @@ plugins {
 
 dependencies {
     api(libs.edc.spi.core)
-    api(libs.edc.spi.dataplane)
-    api(libs.edc.spi.transfer)
-    api(libs.edc.util)
-    implementation(libs.edc.spi.validator)
+    implementation(libs.edc.util)
+    implementation(libs.failsafe.core)
 
+    implementation(project(":extensions:common:gcp:gcp-core"))
 
     // GCP dependencies.
     implementation(platform(libs.googlecloud.bom))
     implementation(libs.googlecloud.bigquery)
     implementation(libs.googlecloud.iam.admin)
-    implementation(libs.googlecloud.storage)
     implementation(libs.googlecloud.iam.credentials)
-    implementation(libs.googleapis.iam)
-
-    testImplementation(libs.edc.junit)
 }
-
-

--- a/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryConsumerResourceDefinitionGenerator.java
+++ b/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryConsumerResourceDefinitionGenerator.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.connector.provision.gcp;
+
+import org.eclipse.edc.connector.transfer.spi.provision.ConsumerResourceDefinitionGenerator;
+import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
+import org.eclipse.edc.gcp.bigquery.BigQueryService;
+import org.eclipse.edc.policy.model.Policy;
+import org.jetbrains.annotations.Nullable;
+
+import static java.util.UUID.randomUUID;
+
+public class BigQueryConsumerResourceDefinitionGenerator implements ConsumerResourceDefinitionGenerator {
+
+    @Override
+    public @Nullable
+    ResourceDefinition generate(DataRequest dataRequest, Policy policy) {
+        var destination = dataRequest.getDataDestination();
+        var id = randomUUID().toString();
+        return BigQueryResourceDefinition.Builder.newInstance()
+                .id(id)
+                .properties(destination.getProperties())
+                .build();
+    }
+
+    @Override
+    public boolean canGenerate(DataRequest dataRequest, Policy policy) {
+        return BigQueryService.BIGQUERY_DATA.equals(dataRequest.getDestinationType());
+    }
+}

--- a/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisionExtension.java
+++ b/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisionExtension.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.connector.provision.gcp;
+
+import org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager;
+import org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestGenerator;
+import org.eclipse.edc.gcp.common.GcpConfiguration;
+import org.eclipse.edc.gcp.iam.IamService;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+
+@Extension(value = BigQueryProvisionExtension.NAME)
+public class BigQueryProvisionExtension implements ServiceExtension {
+    public static final String NAME = "GCP BigQuery Provisioner";
+    @Inject
+    private ProvisionManager provisionManager;
+    @Inject
+    private ResourceManifestGenerator manifestGenerator;
+    @Inject
+    private IamService iamService;
+    @Inject
+    private GcpConfiguration gcpConfiguration;
+    @Inject
+    private TypeManager typeManager;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var monitor = context.getMonitor();
+        var provisioner = BigQueryProvisioner.Builder.newInstance(gcpConfiguration, monitor, iamService, typeManager)
+                .build();
+
+        provisionManager.register(provisioner);
+        manifestGenerator.registerGenerator(new BigQueryConsumerResourceDefinitionGenerator());
+    }
+}

--- a/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisionExtension.java
+++ b/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisionExtension.java
@@ -17,7 +17,6 @@ package org.eclipse.edc.connector.provision.gcp;
 import org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager;
 import org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestGenerator;
 import org.eclipse.edc.gcp.common.GcpConfiguration;
-import org.eclipse.edc.gcp.iam.IamService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
@@ -32,8 +31,6 @@ public class BigQueryProvisionExtension implements ServiceExtension {
     @Inject
     private ResourceManifestGenerator manifestGenerator;
     @Inject
-    private IamService iamService;
-    @Inject
     private GcpConfiguration gcpConfiguration;
     @Inject
     private TypeManager typeManager;
@@ -46,7 +43,7 @@ public class BigQueryProvisionExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var monitor = context.getMonitor();
-        var provisioner = BigQueryProvisioner.Builder.newInstance(gcpConfiguration, monitor, iamService, typeManager)
+        var provisioner = BigQueryProvisioner.Builder.newInstance(gcpConfiguration, monitor, typeManager)
                 .build();
 
         provisionManager.register(provisioner);

--- a/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisionedResource.java
+++ b/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisionedResource.java
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.connector.provision.gcp;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.connector.transfer.spi.types.ProvisionedDataDestinationResource;
+import org.eclipse.edc.gcp.bigquery.BigQueryService;
+
+import java.util.Map;
+
+@JsonDeserialize(builder = BigQueryProvisionedResource.Builder.class)
+@JsonTypeName("dataspaceconnector:bigqueryprovisionedresource")
+public class BigQueryProvisionedResource extends ProvisionedDataDestinationResource {
+    private BigQueryProvisionedResource() {
+    }
+
+    public String getQuery() {
+        return getDataAddress().getStringProperty(BigQueryService.QUERY);
+    }
+
+    public String getTable() {
+        return getDataAddress().getStringProperty(BigQueryService.TABLE);
+    }
+
+    public String getDataset() {
+        return getDataAddress().getStringProperty(BigQueryService.DATASET);
+    }
+
+    public String getServiceAccountName() {
+        return getDataAddress().getStringProperty(BigQueryService.SERVICE_ACCOUNT_NAME);
+    }
+
+    public String getProject() {
+        return getDataAddress().getStringProperty(BigQueryService.PROJECT);
+    }
+
+    public String getCustomerName() {
+        return getDataAddress().getStringProperty(BigQueryService.CUSTOMER_NAME);
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends
+            ProvisionedDataDestinationResource.Builder<BigQueryProvisionedResource, BigQueryProvisionedResource.Builder> {
+
+        private Builder() {
+            super(new BigQueryProvisionedResource());
+            dataAddressBuilder.type(BigQueryService.BIGQUERY_DATA);
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder properties(Map<String, Object> properties) {
+            dataAddressBuilder.properties(properties);
+            return this;
+        }
+
+        public Builder query(String query) {
+            dataAddressBuilder.property(BigQueryService.QUERY, query);
+            return this;
+        }
+
+        public Builder project(String project) {
+            dataAddressBuilder.property(BigQueryService.PROJECT, project);
+            return this;
+        }
+
+        public Builder table(String table) {
+            dataAddressBuilder.property(BigQueryService.TABLE, table);
+            return this;
+        }
+
+        public Builder dataset(String dataset) {
+            dataAddressBuilder.property(BigQueryService.DATASET, dataset);
+            return this;
+        }
+
+        public Builder serviceAccountName(String serviceAccountName) {
+            dataAddressBuilder.property(BigQueryService.SERVICE_ACCOUNT_NAME, serviceAccountName);
+            return this;
+        }
+
+        public Builder customerName(String customerName) {
+            dataAddressBuilder.property(BigQueryService.CUSTOMER_NAME, customerName);
+            return this;
+        }
+
+        @Override
+        public Builder resourceName(String name) {
+            dataAddressBuilder.keyName(name);
+            super.resourceName(name);
+            return this;
+        }
+    }
+}

--- a/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisioner.java
+++ b/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisioner.java
@@ -1,0 +1,197 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.connector.provision.gcp;
+
+import org.eclipse.edc.connector.transfer.spi.provision.Provisioner;
+import org.eclipse.edc.connector.transfer.spi.types.DeprovisionedResource;
+import org.eclipse.edc.connector.transfer.spi.types.ProvisionResponse;
+import org.eclipse.edc.connector.transfer.spi.types.ProvisionedResource;
+import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
+import org.eclipse.edc.gcp.bigquery.BigQueryService;
+import org.eclipse.edc.gcp.bigquery.BigQueryServiceImpl;
+import org.eclipse.edc.gcp.bigquery.BigQueryTarget;
+import org.eclipse.edc.gcp.common.GcpAccessToken;
+import org.eclipse.edc.gcp.common.GcpConfiguration;
+import org.eclipse.edc.gcp.common.GcpException;
+import org.eclipse.edc.gcp.common.GcpServiceAccount;
+import org.eclipse.edc.gcp.iam.IamService;
+import org.eclipse.edc.gcp.iam.IamServiceImpl;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.response.ResponseStatus;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.types.TypeManager;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+public class BigQueryProvisioner implements Provisioner<BigQueryResourceDefinition, BigQueryProvisionedResource> {
+    private final GcpConfiguration gcpConfiguration;
+    private final Monitor monitor;
+    private final IamService iamService;
+    private final TypeManager typeManager;
+    private BigQueryService bigQueryService;
+
+    private BigQueryProvisioner(GcpConfiguration gcpConfiguration, Monitor monitor, IamService iamService, TypeManager typeManager) {
+        this.monitor = monitor;
+        this.iamService = iamService;
+        this.gcpConfiguration = gcpConfiguration;
+        this.typeManager = typeManager;
+    }
+
+    @Override
+    public boolean canProvision(ResourceDefinition resourceDefinition) {
+        return resourceDefinition instanceof BigQueryResourceDefinition;
+    }
+
+    @Override
+    public boolean canDeprovision(ProvisionedResource resourceDefinition) {
+        return resourceDefinition instanceof BigQueryProvisionedResource;
+    }
+
+    @Override
+    public CompletableFuture<StatusResult<ProvisionResponse>> provision(
+            BigQueryResourceDefinition resourceDefinition, Policy policy) {
+        var target = getTarget(resourceDefinition);
+        monitor.info("BigQuery Provisioner provision " + target.getTableName());
+        var bqIamService = getIamService(resourceDefinition);
+        var serviceAccountName = getServiceAccountName(resourceDefinition);
+
+        var tableName = Optional.ofNullable(target.table())
+                .orElseGet(() -> {
+                    var generatedTableName = resourceDefinition.getId();
+                    monitor.debug("BigQuery Provisioner table name generated: " + generatedTableName);
+                    return generatedTableName;
+                });
+        var resourceName = tableName + "-table";
+
+        // TODO update target with the generated table name.
+
+        try {
+            String serviceAccountEmail = null;
+            GcpServiceAccount serviceAccount = null;
+            if (serviceAccountName != null) {
+                serviceAccount = bqIamService.getServiceAccount(serviceAccountName);
+                serviceAccountEmail = serviceAccount.getEmail();
+            }
+
+            if (bigQueryService == null) {
+                bigQueryService = BigQueryServiceImpl.Builder.newInstance(gcpConfiguration, target, monitor)
+                        .serviceAccount(serviceAccountEmail)
+                        .build();
+            }
+
+            if (!bigQueryService.tableExists(target)) {
+                monitor.warning("BigQuery Provisioner table " + target.getTableName() + " DOESN'T exist");
+                return completedFuture(StatusResult.failure(ResponseStatus.FATAL_ERROR, "Table " + target.getTableName().toString() + " doesn't exist"));
+            }
+            monitor.info("BigQuery Provisioner table " + target.getTableName().toString() + " exists");
+
+            GcpAccessToken token = null;
+
+            if (serviceAccount != null) {
+                token = bqIamService.createAccessToken(serviceAccount);
+            } else {
+                serviceAccount = new GcpServiceAccount("adc-email", "adc-name", "application default");
+                token = bqIamService.createDefaultAccessToken();
+            }
+            monitor.info("BigQuery Provisioner token ready");
+
+            var resource = getProvisionedResource(resourceDefinition, resourceName, tableName, serviceAccount);
+            var response = ProvisionResponse.Builder.newInstance().resource(resource).secretToken(token).build();
+            return CompletableFuture.completedFuture(StatusResult.success(response));
+        } catch (GcpException gcpException) {
+            return completedFuture(StatusResult.failure(ResponseStatus.FATAL_ERROR, gcpException.toString()));
+        }
+    }
+
+    private BigQueryProvisionedResource getProvisionedResource(BigQueryResourceDefinition resourceDefinition, String resourceName, String table, GcpServiceAccount serviceAccount) {
+        String serviceAccountName = null;
+        if (serviceAccount != null) {
+            serviceAccountName = serviceAccount.getName();
+        }
+
+        return BigQueryProvisionedResource.Builder.newInstance()
+            .properties(resourceDefinition.getProperties())
+            .id(resourceDefinition.getId())
+            .resourceDefinitionId(resourceDefinition.getId())
+            .transferProcessId(resourceDefinition.getTransferProcessId())
+            .resourceName(resourceName)
+            .project(resourceDefinition.getProject())
+            .dataset(resourceDefinition.getDataset())
+            .table(table)
+            .serviceAccountName(serviceAccountName)
+            .hasToken(true).build();
+    }
+
+    @Override
+    public CompletableFuture<StatusResult<DeprovisionedResource>> deprovision(
+            BigQueryProvisionedResource provisionedResource, Policy policy) {
+        return CompletableFuture.completedFuture(StatusResult.success(
+            DeprovisionedResource.Builder.newInstance()
+                .provisionedResourceId(provisionedResource.getId()).build()));
+    }
+
+    private String getServiceAccountName(BigQueryResourceDefinition resourceDefinition) {
+        if (resourceDefinition.getServiceAccountName() != null) {
+            // TODO verify service account name from resource definition before returning.
+            return resourceDefinition.getServiceAccountName();
+        }
+
+        return gcpConfiguration.getServiceAccountName();
+    }
+
+    private IamService getIamService(BigQueryResourceDefinition resourceDefinition) {
+        var target = getTarget(resourceDefinition);
+        // TODO verify the credentials for IAM access.
+        return IamServiceImpl.Builder.newInstance(monitor, target.project())
+            .build();
+    }
+
+    private BigQueryTarget getTarget(BigQueryResourceDefinition resourceDefinition) {
+        var project = resourceDefinition.getProject();
+        var dataset = resourceDefinition.getDataset();
+        var table = resourceDefinition.getTable();
+
+        if (project == null) {
+            project = gcpConfiguration.getProjectId();
+        }
+
+        return new BigQueryTarget(project, dataset, table);
+    }
+
+    public static class Builder {
+        private final BigQueryProvisioner bqProvisioner;
+
+        public static Builder newInstance(GcpConfiguration gcpConfiguration, Monitor monitor, IamService iamService, TypeManager typeManager) {
+            return new Builder(gcpConfiguration, monitor, iamService, typeManager);
+        }
+
+        private Builder(GcpConfiguration gcpConfiguration, Monitor monitor, IamService iamService, TypeManager typeManager) {
+            bqProvisioner = new BigQueryProvisioner(gcpConfiguration, monitor, iamService, typeManager);
+        }
+
+        public Builder bigQueryService(BigQueryService bigQueryService) {
+            bqProvisioner.bigQueryService = bigQueryService;
+            return this;
+        }
+
+        public BigQueryProvisioner build() {
+            return bqProvisioner;
+        }
+    }
+}

--- a/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisioner.java
+++ b/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisioner.java
@@ -42,13 +42,11 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 public class BigQueryProvisioner implements Provisioner<BigQueryResourceDefinition, BigQueryProvisionedResource> {
     private final GcpConfiguration gcpConfiguration;
     private final Monitor monitor;
-    private final IamService iamService;
     private final TypeManager typeManager;
     private BigQueryService bigQueryService;
 
-    private BigQueryProvisioner(GcpConfiguration gcpConfiguration, Monitor monitor, IamService iamService, TypeManager typeManager) {
+    private BigQueryProvisioner(GcpConfiguration gcpConfiguration, Monitor monitor, TypeManager typeManager) {
         this.monitor = monitor;
-        this.iamService = iamService;
         this.gcpConfiguration = gcpConfiguration;
         this.typeManager = typeManager;
     }
@@ -68,6 +66,7 @@ public class BigQueryProvisioner implements Provisioner<BigQueryResourceDefiniti
             BigQueryResourceDefinition resourceDefinition, Policy policy) {
         var target = getTarget(resourceDefinition);
         monitor.info("BigQuery Provisioner provision " + target.getTableName());
+        // TODO check if injected IAM service can be used (ADC / refresher).
         var bqIamService = getIamService(resourceDefinition);
         var serviceAccountName = getServiceAccountName(resourceDefinition);
 
@@ -177,12 +176,12 @@ public class BigQueryProvisioner implements Provisioner<BigQueryResourceDefiniti
     public static class Builder {
         private final BigQueryProvisioner bqProvisioner;
 
-        public static Builder newInstance(GcpConfiguration gcpConfiguration, Monitor monitor, IamService iamService, TypeManager typeManager) {
-            return new Builder(gcpConfiguration, monitor, iamService, typeManager);
+        public static Builder newInstance(GcpConfiguration gcpConfiguration, Monitor monitor, TypeManager typeManager) {
+            return new Builder(gcpConfiguration, monitor, typeManager);
         }
 
-        private Builder(GcpConfiguration gcpConfiguration, Monitor monitor, IamService iamService, TypeManager typeManager) {
-            bqProvisioner = new BigQueryProvisioner(gcpConfiguration, monitor, iamService, typeManager);
+        private Builder(GcpConfiguration gcpConfiguration, Monitor monitor, TypeManager typeManager) {
+            bqProvisioner = new BigQueryProvisioner(gcpConfiguration, monitor, typeManager);
         }
 
         public Builder bigQueryService(BigQueryService bigQueryService) {

--- a/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryResourceDefinition.java
+++ b/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryResourceDefinition.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.connector.provision.gcp;
+
+import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
+import org.eclipse.edc.gcp.bigquery.BigQueryService;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+
+public class BigQueryResourceDefinition extends ResourceDefinition {
+    private Map<String, Object> properties = new HashMap<String, Object>();
+
+    private BigQueryResourceDefinition() {
+    }
+
+    public String getProject() {
+        return getString(BigQueryService.PROJECT);
+    }
+
+    public String getDataset() {
+        return getString(BigQueryService.DATASET);
+    }
+
+    public String getTable() {
+        return getString(BigQueryService.TABLE);
+    }
+
+    public String getQuery() {
+        return getString(BigQueryService.QUERY);
+    }
+
+    public String getServiceAccountName() {
+        return getString(BigQueryService.SERVICE_ACCOUNT_NAME);
+    }
+
+    public String getCustomerName() {
+        return getString(BigQueryService.CUSTOMER_NAME);
+    }
+
+    private String getString(String key) {
+        var value = Optional.ofNullable(properties.get(EDC_NAMESPACE + key)).orElseGet(() -> properties.get(key));
+        if (value != null) {
+            return (String) value;
+        }
+
+        return null;
+    }
+
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return initializeBuilder(new Builder())
+            .properties(properties);
+    }
+
+    public static class Builder extends ResourceDefinition.Builder<BigQueryResourceDefinition, Builder> {
+
+        private Builder() {
+            super(new BigQueryResourceDefinition());
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder property(String key, String value) {
+            resourceDefinition.properties.put(key, value);
+            return this;
+        }
+
+        public Builder properties(Map<String, Object> properties) {
+            resourceDefinition.properties = properties;
+            return this;
+        }
+
+        @Override
+        protected void verify() {
+            super.verify();
+            // TODO verify required fields.
+        }
+    }
+}

--- a/extensions/control-plane/provision/provision-bigquery/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/control-plane/provision/provision-bigquery/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2023 Google LLC
+#  Copyright (c) 2024 Google LLC
 #
 #  This program and the accompanying materials are made available under the
 #  terms of the Apache License, Version 2.0 which is available at
@@ -12,5 +12,4 @@
 #
 #
 
-org.eclipse.edc.gcp.common.GcpExtension
-org.eclipse.edc.gcp.bigquery.BigQueryDataAddressValidatorExtension
+org.eclipse.edc.connector.provision.gcp.BigQueryProvisionExtension

--- a/extensions/control-plane/provision/provision-bigquery/src/test/java/org/eclipse/edc/connector/provision/gcp/BigQueryConsumerResourceDefinitionGeneratorTest.java
+++ b/extensions/control-plane/provision/provision-bigquery/src/test/java/org/eclipse/edc/connector/provision/gcp/BigQueryConsumerResourceDefinitionGeneratorTest.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.connector.provision.gcp;
+
+import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.gcp.bigquery.BigQueryService;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class BigQueryConsumerResourceDefinitionGeneratorTest {
+    private static final String TEST_PROJECT = "test-project";
+    private static final String TEST_DATASET = "test-dataset";
+    private static final String TEST_TABLE = "test-table";
+    private BigQueryConsumerResourceDefinitionGenerator generator;
+
+    @BeforeEach
+    void setUp() {
+        generator = new BigQueryConsumerResourceDefinitionGenerator();
+    }
+
+    @Test
+    void generate() {
+        var destination = DataAddress.Builder.newInstance().type(BigQueryService.BIGQUERY_DATA)
+                .property(BigQueryService.PROJECT, TEST_PROJECT)
+                .property(BigQueryService.DATASET, TEST_DATASET)
+                .property(BigQueryService.TABLE, TEST_TABLE)
+                .build();
+        var asset = Asset.Builder.newInstance().build();
+        var dr = DataRequest.Builder.newInstance().dataDestination(destination).assetId(asset.getId()).build();
+        var policy = Policy.Builder.newInstance().build();
+
+        var definition = generator.generate(dr, policy);
+
+        assertThat(definition).isInstanceOf(BigQueryResourceDefinition.class);
+        var objectDef = (BigQueryResourceDefinition) definition;
+        assertThat(objectDef.getProject()).isEqualTo(TEST_PROJECT);
+        assertThat(objectDef.getDataset()).isEqualTo(TEST_DATASET);
+        assertThat(objectDef.getId()).satisfies(UUID::fromString);
+    }
+
+    @Test
+    void generate_noDataRequestAsParameter() {
+        var policy = Policy.Builder.newInstance().build();
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> generator.generate(null, policy));
+    }
+
+    @Test
+    void canGenerate() {
+        var destination = DataAddress.Builder.newInstance().type(BigQueryService.BIGQUERY_DATA)
+                .build();
+        var asset = Asset.Builder.newInstance().build();
+        var dataRequest = DataRequest.Builder.newInstance().dataDestination(destination).assetId(asset.getId()).build();
+        var policy = Policy.Builder.newInstance().build();
+
+        var definition = generator.canGenerate(dataRequest, policy);
+        assertThat(definition).isTrue();
+    }
+
+    @Test
+    void canGenerate_isNotTypeBigQueryStream() {
+        var destination = DataAddress.Builder.newInstance().type("NonBigQueryData")
+                .build();
+        var asset = Asset.Builder.newInstance().build();
+        var dataRequest = DataRequest.Builder.newInstance().dataDestination(destination).assetId(asset.getId()).build();
+        var policy = Policy.Builder.newInstance().build();
+
+        var definition = generator.canGenerate(dataRequest, policy);
+        assertThat(definition).isFalse();
+    }
+}

--- a/extensions/control-plane/provision/provision-bigquery/src/test/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisionerTest.java
+++ b/extensions/control-plane/provision/provision-bigquery/src/test/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisionerTest.java
@@ -1,0 +1,156 @@
+/*
+ *  Copyright (c) 2024 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LLC
+ *
+ */
+
+package org.eclipse.edc.connector.provision.gcp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.connector.transfer.spi.types.ProvisionedResource;
+import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
+import org.eclipse.edc.gcp.bigquery.BigQueryService;
+import org.eclipse.edc.gcp.bigquery.BigQueryTarget;
+import org.eclipse.edc.gcp.common.GcpConfiguration;
+import org.eclipse.edc.gcp.iam.IamService;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+class BigQueryProvisionerTest {
+    private static final String TEST_PROJECT = "test-project";
+    private static final String TEST_DATASET = "test-dataset";
+    private static final String TEST_TABLE = "test-table";
+    private static final String RESOURCE_ID = "mandatory-id";
+    private static final String RESOURCE_DEFINITION_ID = "resource-definition-id";
+    private static final String TRANSFER_ID = "transfer-id";
+    private static final String CUSTOMER_NAME = "customer-name";
+    private static final String RESOURCE_NAME = "resource-name";
+    private final BigQueryTarget bigQueryTarget = new BigQueryTarget(TEST_PROJECT, TEST_DATASET, TEST_TABLE);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private BigQueryProvisioner bigQueryProvisioner;
+    private Monitor monitor = mock();
+    private GcpConfiguration gcpConfiguration = mock();
+    private IamService iamService = mock();
+    private BigQueryService bigQueryService = mock();
+    private TypeManager typeManager = mock();
+
+    @BeforeEach
+    void setUp() {
+        reset(gcpConfiguration);
+        reset(monitor);
+        reset(iamService);
+        reset(bigQueryService);
+        reset(typeManager);
+
+        when(typeManager.getMapper()).thenReturn(objectMapper);
+
+        bigQueryProvisioner = BigQueryProvisioner.Builder.newInstance(gcpConfiguration, monitor,
+                iamService, typeManager)
+            .bigQueryService(bigQueryService)
+            .build();
+    }
+
+    @Test
+    void testCanProvisionTrue() {
+        var resourceDefinition = BigQueryResourceDefinition.Builder.newInstance()
+                .id(RESOURCE_ID)
+                .property(BigQueryService.PROJECT, TEST_PROJECT)
+                .property(BigQueryService.DATASET, TEST_DATASET)
+                .property(BigQueryService.TABLE, TEST_TABLE)
+                .build();
+
+        assertThat(bigQueryProvisioner.canProvision(resourceDefinition)).isTrue();
+    }
+
+    @Test
+    void testCanProvisionFalse() {
+        assertThat(bigQueryProvisioner.canProvision(new ResourceDefinition() {
+            @Override
+            public <RD extends ResourceDefinition, B extends Builder<RD, B>> B toBuilder() {
+                return null;
+            }
+        })).isFalse();
+    }
+
+    @Test
+    void testCanDeprovisionTrue() {
+        var provisionedResource = BigQueryProvisionedResource.Builder.newInstance()
+                .id(RESOURCE_ID)
+                .transferProcessId(TRANSFER_ID)
+                .resourceDefinitionId(RESOURCE_DEFINITION_ID)
+                .resourceName(RESOURCE_NAME)
+                .build();
+
+        assertThat(bigQueryProvisioner.canDeprovision(provisionedResource)).isTrue();
+    }
+
+    @Test
+    void testCanDeprovisionFalse() {
+        assertThat(bigQueryProvisioner.canDeprovision(new ProvisionedResource() {
+        })).isFalse();
+    }
+
+    @Test
+    void provisionSuccess() throws InterruptedException, ExecutionException {
+        var resourceDefinition = BigQueryResourceDefinition.Builder.newInstance()
+                .id(RESOURCE_ID)
+                .transferProcessId(TRANSFER_ID)
+                .property(BigQueryService.PROJECT, TEST_PROJECT)
+                .property(BigQueryService.DATASET, TEST_DATASET)
+                .property(BigQueryService.TABLE, TEST_TABLE)
+                .property(BigQueryService.CUSTOMER_NAME, CUSTOMER_NAME)
+                .build();
+
+        var policy = Policy.Builder.newInstance().build();
+
+        when(bigQueryService.tableExists(bigQueryTarget)).thenReturn(true);
+
+        var response = bigQueryProvisioner.provision(resourceDefinition, policy).join().getContent();
+        assertThat(response.getResource()).isInstanceOfSatisfying(BigQueryProvisionedResource.class, resource -> {
+            assertThat(resource.getId()).isEqualTo(RESOURCE_ID);
+            assertThat(resource.getTransferProcessId()).isEqualTo(TRANSFER_ID);
+            assertThat(resource.getProject()).isEqualTo(TEST_PROJECT);
+            assertThat(resource.getDataset()).isEqualTo(TEST_DATASET);
+            assertThat(resource.getTable()).isEqualTo(TEST_TABLE);
+            assertThat(resource.hasToken()).isTrue();
+            assertThat(resource.getCustomerName()).isEqualTo(CUSTOMER_NAME);
+        });
+    }
+
+    @Test
+    void provisionFailsIfTableDoesntExist() throws InterruptedException, ExecutionException {
+        var resourceDefinition = BigQueryResourceDefinition.Builder.newInstance()
+                .id(RESOURCE_ID)
+                .transferProcessId(TRANSFER_ID)
+                .property(BigQueryService.PROJECT, TEST_PROJECT)
+                .property(BigQueryService.DATASET, TEST_DATASET)
+                .property(BigQueryService.TABLE, TEST_TABLE)
+                .property(BigQueryService.CUSTOMER_NAME, CUSTOMER_NAME)
+                .build();
+
+        var policy = Policy.Builder.newInstance().build();
+
+        when(bigQueryService.tableExists(bigQueryTarget)).thenReturn(false);
+
+        var response = bigQueryProvisioner.provision(resourceDefinition, policy).join();
+        assertThat(response.failed()).isTrue();
+    }
+}

--- a/extensions/control-plane/provision/provision-bigquery/src/test/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisionerTest.java
+++ b/extensions/control-plane/provision/provision-bigquery/src/test/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisionerTest.java
@@ -20,7 +20,6 @@ import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
 import org.eclipse.edc.gcp.bigquery.BigQueryService;
 import org.eclipse.edc.gcp.bigquery.BigQueryTarget;
 import org.eclipse.edc.gcp.common.GcpConfiguration;
-import org.eclipse.edc.gcp.iam.IamService;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -48,7 +47,6 @@ class BigQueryProvisionerTest {
     private BigQueryProvisioner bigQueryProvisioner;
     private Monitor monitor = mock();
     private GcpConfiguration gcpConfiguration = mock();
-    private IamService iamService = mock();
     private BigQueryService bigQueryService = mock();
     private TypeManager typeManager = mock();
 
@@ -56,14 +54,12 @@ class BigQueryProvisionerTest {
     void setUp() {
         reset(gcpConfiguration);
         reset(monitor);
-        reset(iamService);
         reset(bigQueryService);
         reset(typeManager);
 
         when(typeManager.getMapper()).thenReturn(objectMapper);
 
-        bigQueryProvisioner = BigQueryProvisioner.Builder.newInstance(gcpConfiguration, monitor,
-                iamService, typeManager)
+        bigQueryProvisioner = BigQueryProvisioner.Builder.newInstance(gcpConfiguration, monitor, typeManager)
             .bigQueryService(bigQueryService)
             .build();
     }

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsConsumerResourceDefinitionGenerator.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsConsumerResourceDefinitionGenerator.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *       ZF Friedrichshafen AG - improvements (refactoring of generate method)
  *       SAP SE - refactoring
  *

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionExtension.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionExtension.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionedResource.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionedResource.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisioner.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisioner.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsResourceDefinition.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsResourceDefinition.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/control-plane/provision/provision-gcs/src/test/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerTest.java
+++ b/extensions/control-plane/provision/provision-gcs/src/test/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerTest.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/extensions/data-plane/data-plane-google-storage/src/test/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSourceTest.java
+++ b/extensions/data-plane/data-plane-google-storage/src/test/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSourceTest.java
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Google LCC - Initial implementation
+ *       Google LLC - Initial implementation
  *
  */
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ assertj = { module = "org.assertj:assertj-core", version = "3.24.2" }
 edc-core-dataplane = { module = "org.eclipse.edc:data-plane-core", version.ref = "edc" }
 edc-core-dataplane-util = { module = "org.eclipse.edc:data-plane-util", version.ref = "edc" }
 edc-junit = { module = "org.eclipse.edc:junit", version.ref = "edc" }
+edc-control-plane-api = { module = "org.eclipse.edc:control-plane-api", version.ref = "edc" }
 edc-spi-catalog = { module = "org.eclipse.edc:catalog-spi", version.ref = "edc" }
 edc-spi-contract = { module = "org.eclipse.edc:contract-spi", version.ref = "edc" }
 edc-spi-core = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
@@ -29,11 +30,12 @@ failsafe-okhttp = { module = "dev.failsafe:failsafe-okhttp", version.ref = "fail
 
 # Google dependencies
 googlecloud-bom = { module = "com.google.cloud:libraries-bom", version.ref = "googleCloudBom" }
-googlecloud-core = { module = "com.google.cloud:google-cloud-core"}
-googlecloud-iam-admin = { module = "com.google.cloud:google-iam-admin"}
-googlecloud-iam-credentials = { module = "com.google.cloud:google-cloud-iamcredentials"}
-googlecloud-secretmanager = { module = "com.google.cloud:google-cloud-secretmanager"}
-googlecloud-storage = { module = "com.google.cloud:google-cloud-storage"}
+googlecloud-core = { module = "com.google.cloud:google-cloud-core" }
+googlecloud-iam-admin = { module = "com.google.cloud:google-iam-admin" }
+googlecloud-iam-credentials = { module = "com.google.cloud:google-cloud-iamcredentials" }
+googlecloud-secretmanager = { module = "com.google.cloud:google-cloud-secretmanager" }
+googlecloud-storage = { module = "com.google.cloud:google-cloud-storage" }
+googlecloud-bigquery = { module = "com.google.cloud:google-cloud-bigquery" }
 googleapis-iam = { module = "com.google.apis:google-api-services-iam", version.ref = "googleApisIam"}
 
 [bundles]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,6 +42,7 @@ include(":extensions:common:vault:vault-gcp")
 
 // control plane extensions
 include(":extensions:control-plane:provision:provision-gcs")
+include(":extensions:control-plane:provision:provision-bigquery")
 
 // data plane extensions
 include(":extensions:data-plane:data-plane-google-storage")


### PR DESCRIPTION
## What this PR changes/adds

Added:
- extensions/common/gcp/gcp-core/.../bigquery : common classes including BQ DataAddress, service client, and theBigQuery DataAddress Validator Extension to register DataAddress validators
- extensions/control-plane/provision/provision-bigquery : BQ provisioner for generating access token for data plane sink, including the BigQuery Provision Extension to register the provisioner

## Why it does that

The PR adds first basic version of the BigQuery extension to exchange data to and from BigQuery tables.

## Further notes

* Also included small license fix for GCS and Secret Manager extensions

* To be added in following PR:
    - BigQuery data plane

* Limitations for this version:
    - provisioner requires destination table to exist, doesn't create new table if it doesn't
    - data is committed to the destination table only if no error occurred during the data transmission
    - no transmission retry in case of error
    - results are fetched via pages (size is fixed, 4 rows), max. size for serialized page data is 16 KiB

## Linked Issue(s)

#50 
