### PR TITLE
fix: move settings into extensions

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -4,14 +4,15 @@ maven/mavencentral/com.apicatalog/titanium-json-ld/1.0.0, Apache-2.0, approved, 
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.1, Apache-2.0, approved, #8912
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.10.3, Apache-2.0, approved, CQ21280
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.3, Apache-2.0, approved, #7947
-maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.1, Apache-2.0, approved, #11606
+maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.2, Apache-2.0, approved, #11606
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.16.1, Apache-2.0 AND MIT, approved, #11602
+maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.16.2, Apache-2.0 AND MIT, approved, #11602
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.3, Apache-2.0, approved, #7934
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.1, Apache-2.0, approved, #11605
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.1, Apache-2.0, approved, #11853
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.2, Apache-2.0, approved, #11605
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.2, Apache-2.0, approved, #11853
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.15.3, Apache-2.0, approved, #9241
-maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.16.1, Apache-2.0, approved, #11856
-maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.16.1, Apache-2.0, approved, #11852
+maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.16.2, Apache-2.0, approved, #11856
+maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.16.2, Apache-2.0, approved, #11852
 maven/mavencentral/com.github.docker-java/docker-java-api/3.3.6, Apache-2.0, approved, #10346
 maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.6, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #7946
 maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.6, Apache-2.0, approved, #7942
@@ -48,13 +49,13 @@ maven/mavencentral/com.google.cloud/libraries-bom/26.33.0, None, restricted, #13
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
 maven/mavencentral/com.google.code.gson/gson/2.8.9, Apache-2.0, approved, CQ23496
-maven/mavencentral/com.google.collections/google-collections/1.0, Apache-2.0, approved, CQ3285
 maven/mavencentral/com.google.crypto.tink/tink/1.12.0, Apache-2.0, approved, #12041
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.18.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.21.1, Apache-2.0, approved, #9834
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.23.0, Apache-2.0, approved, #11083
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.24.1, Apache-2.0, approved, #12448
+maven/mavencentral/com.google.errorprone/error_prone_annotations/2.26.1, Apache-2.0, approved, #13657
 maven/mavencentral/com.google.guava/failureaccess/1.0.1, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/failureaccess/1.0.2, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/guava/29.0-android, Apache-2.0, approved, clearlydefined
@@ -64,7 +65,7 @@ maven/mavencentral/com.google.guava/guava/32.0.0-android, Apache-2.0 AND CC0-1.0
 maven/mavencentral/com.google.guava/guava/32.0.0-jre, Apache-2.0 AND CC0-1.0 AND CC-PDDC, approved, #8772
 maven/mavencentral/com.google.guava/guava/32.0.1-jre, Apache-2.0 AND CC0-1.0 AND CC-PDDC, approved, #8772
 maven/mavencentral/com.google.guava/guava/32.1.3-jre, Apache-2.0 AND CC0-1.0 AND LicenseRef-Public-Domain, approved, #9229
-maven/mavencentral/com.google.guava/guava/33.0.0-jre, Apache-2.0 AND CC0-1.0, approved, #12173
+maven/mavencentral/com.google.guava/guava/33.1.0-jre, Apache-2.0 AND CC0-1.0, approved, #13675
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
 maven/mavencentral/com.google.http-client/google-http-client-apache-v2/1.44.1, Apache-2.0, approved, #13430
 maven/mavencentral/com.google.http-client/google-http-client-appengine/1.44.1, Apache-2.0, approved, #13425
@@ -80,7 +81,7 @@ maven/mavencentral/com.google.protobuf/protobuf-java/3.24.3, BSD-3-Clause, appro
 maven/mavencentral/com.google.protobuf/protobuf-java/3.25.2, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.google.re2j/re2j/1.7, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.14.0, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #13562
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.14.2, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #13562
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #11156
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.9.3, Apache-2.0 AND MPL-2.0, approved, #3225
@@ -125,8 +126,8 @@ maven/mavencentral/io.perfmark/perfmark-api/0.27.0, Apache-2.0, approved, clearl
 maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.0, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
-maven/mavencentral/jakarta.inject/jakarta.inject-api/2.0.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.0, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7697
+maven/mavencentral/jakarta.inject/jakarta.inject-api/2.0.1, Apache-2.0, approved, ee4j.cdi
+maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jta
 maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, ee4j.validation
 maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.rest
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0, BSD-3-Clause, approved, ee4j.jaxb
@@ -161,7 +162,6 @@ maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.77, MIT, approved, #11593
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.77, MIT AND CC0-1.0, approved, #11595
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.77, MIT, approved, #11596
 maven/mavencentral/org.checkerframework/checker-qual/3.37.0, MIT, approved, clearlydefined
-maven/mavencentral/org.checkerframework/checker-qual/3.41.0, MIT, approved, #12032
 maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, clearlydefined
 maven/mavencentral/org.codehaus.mojo/animal-sniffer-annotations/1.23, MIT, approved, clearlydefined
 maven/mavencentral/org.codehaus.plexus/plexus-classworlds/2.6.0, Apache-2.0 AND Plexus, approved, CQ22821

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpConfiguration.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpConfiguration.java
@@ -14,44 +14,18 @@
 
 package org.eclipse.edc.gcp.common;
 
-import com.google.cloud.ServiceOptions;
-import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.spi.system.ServiceExtensionContext;
-
 /**
  * Common configuration of the connector, provides accessors to parameters.
  */
-public class GcpConfiguration {
-    @Setting(value = "Default GCP project ID for the connector", required = false)
-    public static final String PROJECT_ID = "edc.gcp.project.id";
-
-    @Setting(value = "Default service account name for the connector", required = false)
-    public static final String SACCOUNT_NAME = "edc.gcp.saccount.name";
-
-    @Setting(value = "Default JSON file with service account credentials for the connector", required = false)
-    public static final String SACCOUNT_FILE = "edc.gcp.saccount.file";
-
-    @Setting(value = "Default universe domain for the connector", required = false)
-    public static final String UNIVERSE_DOMAIN = "edc.gcp.universe";
-
-    private String projectId;
-    private String serviceAccountName;
-    private String serviceAccountFile;
-    private String universeDomain;
-
-    public GcpConfiguration(ServiceExtensionContext context) {
-        projectId = context.getSetting(PROJECT_ID, ServiceOptions.getDefaultProjectId());
-        serviceAccountName = context.getSetting(SACCOUNT_NAME, null);
-        serviceAccountFile = context.getSetting(SACCOUNT_FILE, null);
-        universeDomain = context.getSetting(UNIVERSE_DOMAIN, null);
-    }
+public record GcpConfiguration(String projectId, String serviceAccountName, String serviceAccountFile,
+                               String universeDomain) {
 
     /**
      * Project ID for the connector.
      *
      * @return the default project ID of the connector, or the default from the cloud SDK.
      */
-    public String getProjectId() {
+    public String projectId() {
         return projectId;
     }
 
@@ -60,7 +34,7 @@ public class GcpConfiguration {
      *
      * @return the default service account name of the connector, or an empty string if not available.
      */
-    public String getServiceAccountName() {
+    public String serviceAccountName() {
         return serviceAccountName;
     }
 
@@ -69,7 +43,7 @@ public class GcpConfiguration {
      *
      * @return the default service account key file path of the connector, or an empty string if not available.
      */
-    public String getServiceAccountFile() {
+    public String serviceAccountFile() {
         return serviceAccountFile;
     }
 
@@ -78,7 +52,7 @@ public class GcpConfiguration {
      *
      * @return the default universe domain of the connector, or an empty string if not available.
      */
-    public String getUniverseDomain() {
+    public String universeDomain() {
         return universeDomain;
     }
 }

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpExtension.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpExtension.java
@@ -14,10 +14,12 @@
 
 package org.eclipse.edc.gcp.common;
 
+import com.google.cloud.ServiceOptions;
 import org.eclipse.edc.gcp.iam.IamService;
 import org.eclipse.edc.gcp.iam.IamServiceImpl;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 
@@ -27,6 +29,17 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 @Extension(value = GcpExtension.NAME)
 public class GcpExtension implements ServiceExtension {
     public static final String NAME = "GCP";
+    @Setting(value = "Default GCP project ID for the connector", required = false)
+    public static final String PROJECT_ID = "edc.gcp.project.id";
+
+    @Setting(value = "Default service account name for the connector", required = false)
+    public static final String SACCOUNT_NAME = "edc.gcp.saccount.name";
+
+    @Setting(value = "Default JSON file with service account credentials for the connector", required = false)
+    public static final String SACCOUNT_FILE = "edc.gcp.saccount.file";
+
+    @Setting(value = "Default universe domain for the connector", required = false)
+    public static final String UNIVERSE_DOMAIN = "edc.gcp.universe";
 
     private GcpConfiguration gcpConfiguration;
     private IamService iamService;
@@ -39,8 +52,14 @@ public class GcpExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        gcpConfiguration = new GcpConfiguration(context);
-        iamService = IamServiceImpl.Builder.newInstance(context.getMonitor(), gcpConfiguration.getProjectId()).build();
+
+        var projectId = context.getSetting(PROJECT_ID, ServiceOptions.getDefaultProjectId());
+        var serviceAccountName = context.getSetting(SACCOUNT_NAME, null);
+        var serviceAccountFile = context.getSetting(SACCOUNT_FILE, null);
+        var universeDomain = context.getSetting(UNIVERSE_DOMAIN, null);
+
+        gcpConfiguration = new GcpConfiguration(projectId, serviceAccountName, serviceAccountFile, universeDomain);
+        iamService = IamServiceImpl.Builder.newInstance(context.getMonitor(), gcpConfiguration.projectId()).build();
     }
 
     @Provider

--- a/extensions/common/vault/vault-gcp/src/main/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVaultExtension.java
+++ b/extensions/common/vault/vault-gcp/src/main/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVaultExtension.java
@@ -57,7 +57,7 @@ public class GcpSecretManagerVaultExtension implements ServiceExtension {
 
     @Provider
     public Vault createVault(ServiceExtensionContext context) {
-        var project = context.getSetting(VAULT_PROJECT, gcpConfiguration.getProjectId());
+        var project = context.getSetting(VAULT_PROJECT, gcpConfiguration.projectId());
         var monitor = context.getMonitor();
 
         if (isNullOrEmpty(project)) {
@@ -66,7 +66,7 @@ public class GcpSecretManagerVaultExtension implements ServiceExtension {
             monitor.info("GCP Secret Manager vault extension: project loaded from settings " + project);
         }
 
-        var saccountFile = context.getSetting(VAULT_SACCOUNT_FILE, gcpConfiguration.getServiceAccountFile());
+        var saccountFile = context.getSetting(VAULT_SACCOUNT_FILE, gcpConfiguration.serviceAccountFile());
 
         // TODO support multi-region replica.
         var region = context.getConfig().getString(VAULT_REGION);

--- a/extensions/common/vault/vault-gcp/src/test/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVaultExtensionTest.java
+++ b/extensions/common/vault/vault-gcp/src/test/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVaultExtensionTest.java
@@ -21,7 +21,6 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -53,41 +52,41 @@ class GcpSecretManagerVaultExtensionTest {
 
     @Test
     void noSettings_shouldThrowException() {
-        ServiceExtensionContext invalidContext = mock(ServiceExtensionContext.class);
+        var invalidContext = mock(ServiceExtensionContext.class);
         when(invalidContext.getMonitor()).thenReturn(monitor);
         when(invalidContext.getConfig()).thenReturn(ConfigFactory.empty());
 
-        extension.gcpConfiguration = new GcpConfiguration(invalidContext);
+        extension.gcpConfiguration = new GcpConfiguration(null, null, null, null);
 
-        EdcException exception = assertThrows(EdcException.class, () -> extension.createVault(invalidContext));
-        assertThat(exception.getMessage().equals("No setting found for key " + GcpSecretManagerVaultExtension.VAULT_REGION));
+        var exception = assertThrows(EdcException.class, () -> extension.createVault(invalidContext));
+        assertThat(exception.getMessage()).isEqualTo("No setting found for key " + GcpSecretManagerVaultExtension.VAULT_REGION);
     }
 
     @Test
     void onlyProjectSetting_shouldThrowException() {
-        ServiceExtensionContext invalidContext = mock(ServiceExtensionContext.class);
+        var invalidContext = mock(ServiceExtensionContext.class);
         when(invalidContext.getMonitor()).thenReturn(monitor);
         var settings = new HashMap<String, String>();
         settings.put(GcpSecretManagerVaultExtension.VAULT_PROJECT, TEST_PROJECT);
         when(invalidContext.getConfig()).thenReturn(ConfigFactory.fromMap(settings));
 
-        extension.gcpConfiguration = new GcpConfiguration(invalidContext);
+        extension.gcpConfiguration = new GcpConfiguration("projId", null, null, null);
 
-        EdcException exception = assertThrows(EdcException.class, () -> extension.createVault(invalidContext));
-        assertThat(exception.getMessage().equals("No setting found for key " + GcpSecretManagerVaultExtension.VAULT_REGION));
+        var exception = assertThrows(EdcException.class, () -> extension.createVault(invalidContext));
+        assertThat(exception.getMessage()).isEqualTo("No setting found for key " + GcpSecretManagerVaultExtension.VAULT_REGION);
     }
 
     @Test
     void onlyRegionSetting_shouldNotThrowException() {
-        ServiceExtensionContext validContext = mock(ServiceExtensionContext.class);
+        var validContext = mock(ServiceExtensionContext.class);
         when(validContext.getMonitor()).thenReturn(monitor);
         var settings = new HashMap<String, String>();
         settings.put(GcpSecretManagerVaultExtension.VAULT_REGION, TEST_REGION);
         when(validContext.getConfig()).thenReturn(ConfigFactory.fromMap(settings));
 
-        extension.gcpConfiguration = new GcpConfiguration(validContext);
+        extension.gcpConfiguration = new GcpConfiguration(null, null, null, TEST_REGION);
 
-        try (MockedStatic<GcpSecretManagerVault> utilities = Mockito.mockStatic(GcpSecretManagerVault.class)) {
+        try (var utilities = Mockito.mockStatic(GcpSecretManagerVault.class)) {
             utilities.when(() -> GcpSecretManagerVault.createWithDefaultSettings(monitor, TEST_PROJECT, TEST_REGION))
                     .thenReturn(new GcpSecretManagerVault(null, null, null, null));
             extension.createVault(validContext);
@@ -96,16 +95,16 @@ class GcpSecretManagerVaultExtensionTest {
 
     @Test
     void mandatorySettings_shouldNotThrowException() {
-        ServiceExtensionContext validContext = mock(ServiceExtensionContext.class);
+        var validContext = mock(ServiceExtensionContext.class);
         when(validContext.getMonitor()).thenReturn(monitor);
         var settings = new HashMap<String, String>();
         settings.put(GcpSecretManagerVaultExtension.VAULT_PROJECT, TEST_PROJECT);
         settings.put(GcpSecretManagerVaultExtension.VAULT_REGION, TEST_REGION);
         when(validContext.getConfig()).thenReturn(ConfigFactory.fromMap(settings));
 
-        extension.gcpConfiguration = new GcpConfiguration(validContext);
+        extension.gcpConfiguration = new GcpConfiguration(TEST_PROJECT, null, null, TEST_REGION);
 
-        try (MockedStatic<GcpSecretManagerVault> utilities = Mockito.mockStatic(GcpSecretManagerVault.class)) {
+        try (var utilities = Mockito.mockStatic(GcpSecretManagerVault.class)) {
             utilities.when(() -> GcpSecretManagerVault.createWithDefaultSettings(monitor, TEST_PROJECT, TEST_REGION))
                     .thenReturn(new GcpSecretManagerVault(null, null, null, null));
             extension.createVault(validContext);
@@ -118,7 +117,7 @@ class GcpSecretManagerVaultExtensionTest {
             var tempPath = Files.createTempFile(TEST_FILE_PREFIX, TEST_FILE_SUFFIX);
             var accountFilePath = tempPath.toString();
             Files.write(tempPath, ("test account data").getBytes());
-            ServiceExtensionContext validContext = mock(ServiceExtensionContext.class);
+            var validContext = mock(ServiceExtensionContext.class);
             when(validContext.getMonitor()).thenReturn(monitor);
             var settings = new HashMap<String, String>();
             settings.put(GcpSecretManagerVaultExtension.VAULT_PROJECT, TEST_PROJECT);
@@ -126,9 +125,9 @@ class GcpSecretManagerVaultExtensionTest {
             settings.put(GcpSecretManagerVaultExtension.VAULT_SACCOUNT_FILE, accountFilePath);
             when(validContext.getConfig()).thenReturn(ConfigFactory.fromMap(settings));
 
-            extension.gcpConfiguration = new GcpConfiguration(validContext);
+            extension.gcpConfiguration = new GcpConfiguration(TEST_PROJECT, null, accountFilePath, TEST_REGION);
 
-            try (MockedStatic<GcpSecretManagerVault> utilities = Mockito.mockStatic(GcpSecretManagerVault.class)) {
+            try (var utilities = Mockito.mockStatic(GcpSecretManagerVault.class)) {
                 utilities.when(() -> GcpSecretManagerVault.createWithServiceAccountCredentials(eq(monitor), eq(TEST_PROJECT), eq(TEST_REGION), Mockito.any(InputStream.class)))
                         .thenReturn(new GcpSecretManagerVault(null, null, null, null));
                 extension.createVault(validContext);

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionExtension.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionExtension.java
@@ -47,7 +47,7 @@ public class GcsProvisionExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var monitor = context.getMonitor();
-        var storageClient = createDefaultStorageClient(gcpConfiguration.getProjectId());
+        var storageClient = createDefaultStorageClient(gcpConfiguration.projectId());
         var storageService = new StorageServiceImpl(storageClient, monitor);
 
         var provisioner = new GcsProvisioner(gcpConfiguration, monitor, storageService, iamService);

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisioner.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisioner.java
@@ -107,7 +107,7 @@ public class GcsProvisioner implements Provisioner<GcsResourceDefinition, GcsPro
             return resourceDefinition.getServiceAccountName();
         }
 
-        return gcpConfiguration.getServiceAccountName();
+        return gcpConfiguration.serviceAccountName();
     }
 
     @Override

--- a/extensions/control-plane/provision/provision-gcs/src/test/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerTest.java
+++ b/extensions/control-plane/provision/provision-gcs/src/test/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerTest.java
@@ -79,7 +79,7 @@ class GcsProvisionerTest {
         var serviceAccount = new GcpServiceAccount("test-sa", "sa-name", "description");
         var token = new GcpAccessToken("token", 123);
 
-        when(gcpConfiguration.getServiceAccountName()).thenReturn(null);
+        when(gcpConfiguration.serviceAccountName()).thenReturn(null);
 
         when(storageServiceMock.getOrCreateBucket(bucketName, bucketLocation)).thenReturn(bucket);
         when(storageServiceMock.isEmpty(bucketName)).thenReturn(true);
@@ -116,7 +116,7 @@ class GcsProvisionerTest {
         var bucket = new GcsBucket(bucketName);
         var bucketLocation = resourceDefinition.getLocation();
 
-        when(gcpConfiguration.getServiceAccountName()).thenReturn(serviceAccount.getName());
+        when(gcpConfiguration.serviceAccountName()).thenReturn(serviceAccount.getName());
 
         when(storageServiceMock.getOrCreateBucket(bucketName, bucketLocation)).thenReturn(bucket);
         when(storageServiceMock.isEmpty(bucketName)).thenReturn(true);
@@ -146,7 +146,7 @@ class GcsProvisionerTest {
         var bucketName = resourceDefinition.getId();
         var bucketLocation = resourceDefinition.getLocation();
 
-        when(gcpConfiguration.getServiceAccountName()).thenReturn(null);
+        when(gcpConfiguration.serviceAccountName()).thenReturn(null);
         when(storageServiceMock.getOrCreateBucket(bucketName, bucketLocation)).thenReturn(new GcsBucket(bucketName));
         when(storageServiceMock.isEmpty(bucketName)).thenReturn(false);
 


### PR DESCRIPTION
## What this PR changes/adds

This PR moves `@Settings` into the extension class, and fixes some related compile errors and adapts tests

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
