### PR TITLE
refactor: simplify IAM access token creation API

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -240,6 +240,7 @@ maven/mavencentral/org.eclipse.edc/transform-spi/0.6.1-SNAPSHOT, Apache-2.0, app
 maven/mavencentral/org.eclipse.edc/util-lib/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/util/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/validator-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/verifiable-credentials-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/web-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api/5.0.2, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-websocket-api/2.0.0, EPL-2.0 OR Apache-2.0, approved, rt.jetty

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -5,13 +5,11 @@ maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.1, Apache-2.0, approved, 
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.10.3, Apache-2.0, approved, CQ21280
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.3, Apache-2.0, approved, #7947
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.1, Apache-2.0, approved, #11606
-maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.2, Apache-2.0, approved, #11606
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.17.0, Apache-2.0, approved, #13672
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.16.1, Apache-2.0 AND MIT, approved, #11602
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.17.0, , approved, #13665
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.3, Apache-2.0, approved, #7934
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.1, Apache-2.0, approved, #11605
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.2, Apache-2.0, approved, #11605
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.17.0, Apache-2.0, approved, #13671
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.1, Apache-2.0, approved, #11853
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.17.0, Apache-2.0, approved, #14160

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/service/BigQueryFactory.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/service/BigQueryFactory.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.gcp.bigquery.service;
 
 import com.google.cloud.bigquery.BigQuery;
+import org.eclipse.edc.gcp.common.GcpServiceAccount;
 
 import java.io.IOException;
 
@@ -26,8 +27,8 @@ public interface BigQueryFactory {
     /**
      * Provides instances of the BigQuery service using specific service account name.
      *
-     * @param serviceAccountName the service account to use to execute bigquery calls
+     * @param serviceAccount the service account to use to execute bigquery calls
      * @return the instance of the service
      */
-    BigQuery createBigQuery(String serviceAccountName) throws IOException;
+    BigQuery createBigQuery(GcpServiceAccount serviceAccount) throws IOException;
 }

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpConfiguration.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpConfiguration.java
@@ -32,7 +32,7 @@ public record GcpConfiguration(String projectId, String serviceAccountName, Stri
     /**
      * Service account name for the connector.
      *
-     * @return the default service account name of the connector, or an empty string if not available.
+     * @return the default service account name of the connector, or null if not available.
      */
     public String serviceAccountName() {
         return serviceAccountName;
@@ -41,7 +41,7 @@ public record GcpConfiguration(String projectId, String serviceAccountName, Stri
     /**
      * Service account JSON key file for the connector.
      *
-     * @return the default service account key file path of the connector, or an empty string if not available.
+     * @return the default service account key file path of the connector, or null if not available.
      */
     public String serviceAccountFile() {
         return serviceAccountFile;
@@ -50,7 +50,7 @@ public record GcpConfiguration(String projectId, String serviceAccountName, Stri
     /**
      * Universe domain for the connector.
      *
-     * @return the default universe domain of the connector, or an empty string if not available.
+     * @return the default universe domain of the connector, or null if not available.
      */
     public String universeDomain() {
         return universeDomain;

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpExtension.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpExtension.java
@@ -59,7 +59,7 @@ public class GcpExtension implements ServiceExtension {
         var universeDomain = context.getSetting(UNIVERSE_DOMAIN, null);
 
         gcpConfiguration = new GcpConfiguration(projectId, serviceAccountName, serviceAccountFile, universeDomain);
-        iamService = IamServiceImpl.Builder.newInstance(context.getMonitor(), gcpConfiguration.projectId()).build();
+        iamService = IamServiceImpl.Builder.newInstance(context.getMonitor(), gcpConfiguration).build();
     }
 
     @Provider

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamService.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamService.java
@@ -22,6 +22,8 @@ import org.eclipse.edc.gcp.common.GcpServiceAccount;
  * Wrapper around GCP IAM-API for decoupling.
  */
 public interface IamService {
+    GcpServiceAccount ADC_SERVICE_ACCOUNT = new GcpServiceAccount("adc-email", "adc-name", "application default");
+
     /**
      * Returns the existing service account with the matching name.
      *
@@ -33,15 +35,9 @@ public interface IamService {
     /**
      * Creates a temporary valid OAunth2.0 access token for the service account
      *
-     * @param serviceAccount The service account the token should be created for
+     * @param serviceAccount service account the token should be created for;
+     *                       if null or ADC_SERVICE_ACCOUNT, access token from ADC is created.
      * @return {@link GcpAccessToken}
      */
     GcpAccessToken createAccessToken(GcpServiceAccount serviceAccount);
-
-    /**
-     * Creates a temporary valid OAunth2.0 access token using the application default account credentials.
-     *
-     * @return {@link GcpAccessToken}
-     */
-    GcpAccessToken createDefaultAccessToken();
 }

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamService.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamService.java
@@ -36,7 +36,7 @@ public interface IamService {
      * Creates a temporary valid OAunth2.0 access token for the service account
      *
      * @param serviceAccount service account the token should be created for;
-     *                       if null or ADC_SERVICE_ACCOUNT, access token from ADC is created.
+     *                       if ADC_SERVICE_ACCOUNT, access token from ADC is created.
      * @return {@link GcpAccessToken}
      */
     GcpAccessToken createAccessToken(GcpServiceAccount serviceAccount);

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
@@ -67,6 +67,10 @@ public class IamServiceImpl implements IamService {
 
     @Override
     public GcpAccessToken createAccessToken(GcpServiceAccount serviceAccount) {
+        if (serviceAccount == null || serviceAccount.equals(ADC_SERVICE_ACCOUNT)) {
+            return applicationDefaultCredentials.getAccessToken();
+        }
+
         try (var iamCredentialsClient = iamCredentialsClientSupplier.get()) {
             var name = ServiceAccountName.of("-", serviceAccount.getEmail());
             var lifetime = Duration.newBuilder().setSeconds(ONE_HOUR_IN_S).build();
@@ -82,11 +86,6 @@ public class IamServiceImpl implements IamService {
         } catch (Exception e) {
             throw new GcpException("Error creating service account token:\n" + e);
         }
-    }
-
-    @Override
-    public GcpAccessToken createDefaultAccessToken() {
-        return applicationDefaultCredentials.getAccessToken();
     }
 
     private String getServiceAccountEmail(String name, String project) {

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
@@ -49,6 +49,10 @@ public class IamServiceImpl implements IamService {
 
     @Override
     public GcpServiceAccount getServiceAccount(String serviceAccountName) {
+        if (serviceAccountName == null) {
+            return ADC_SERVICE_ACCOUNT;
+        }
+
         try (var client = iamClientSupplier.get()) {
             var serviceAccountEmail = getServiceAccountEmail(serviceAccountName, gcpProjectId);
             var name = ServiceAccountName.of(gcpProjectId, serviceAccountEmail).toString();

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
@@ -71,7 +71,7 @@ public class IamServiceImpl implements IamService {
 
     @Override
     public GcpAccessToken createAccessToken(GcpServiceAccount serviceAccount) {
-        if (serviceAccount == null || serviceAccount.equals(ADC_SERVICE_ACCOUNT)) {
+        if (serviceAccount.equals(ADC_SERVICE_ACCOUNT)) {
             return applicationDefaultCredentials.getAccessToken();
         }
 

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/iam/IamServiceImpl.java
@@ -24,6 +24,7 @@ import com.google.cloud.iam.credentials.v1.IamCredentialsClient;
 import com.google.cloud.iam.credentials.v1.ServiceAccountName;
 import com.google.protobuf.Duration;
 import org.eclipse.edc.gcp.common.GcpAccessToken;
+import org.eclipse.edc.gcp.common.GcpConfiguration;
 import org.eclipse.edc.gcp.common.GcpException;
 import org.eclipse.edc.gcp.common.GcpServiceAccount;
 import org.eclipse.edc.spi.monitor.Monitor;
@@ -37,25 +38,29 @@ import java.util.function.Supplier;
 public class IamServiceImpl implements IamService {
     private static final long ONE_HOUR_IN_S = TimeUnit.HOURS.toSeconds(1);
     private final Monitor monitor;
-    private final String gcpProjectId;
+    private final GcpConfiguration gcpConfiguration;
     private Supplier<IAMClient> iamClientSupplier;
     private Supplier<IamCredentialsClient> iamCredentialsClientSupplier;
     private AccessTokenProvider applicationDefaultCredentials;
 
-    private IamServiceImpl(Monitor monitor, String gcpProjectId) {
+    private IamServiceImpl(Monitor monitor, GcpConfiguration gcpConfiguration) {
         this.monitor = monitor;
-        this.gcpProjectId = gcpProjectId;
+        this.gcpConfiguration = gcpConfiguration;
     }
 
     @Override
     public GcpServiceAccount getServiceAccount(String serviceAccountName) {
-        if (serviceAccountName == null) {
+        if (serviceAccountName == null && gcpConfiguration.serviceAccountName() == null) {
             return ADC_SERVICE_ACCOUNT;
         }
 
+        if (serviceAccountName == null) {
+            serviceAccountName = gcpConfiguration.serviceAccountName();
+        }
+
         try (var client = iamClientSupplier.get()) {
-            var serviceAccountEmail = getServiceAccountEmail(serviceAccountName, gcpProjectId);
-            var name = ServiceAccountName.of(gcpProjectId, serviceAccountEmail).toString();
+            var serviceAccountEmail = getServiceAccountEmail(serviceAccountName, gcpConfiguration.projectId());
+            var name = ServiceAccountName.of(gcpConfiguration.projectId(), serviceAccountEmail).toString();
             var response = client.getServiceAccount(name);
 
             return new GcpServiceAccount(response.getEmail(), response.getName(), response.getDescription());
@@ -99,12 +104,12 @@ public class IamServiceImpl implements IamService {
     public static class Builder {
         private IamServiceImpl iamServiceImpl;
 
-        private Builder(Monitor monitor, String gcpProjectId) {
-            iamServiceImpl = new IamServiceImpl(monitor, gcpProjectId);
+        private Builder(Monitor monitor, GcpConfiguration gcpConfiguration) {
+            iamServiceImpl = new IamServiceImpl(monitor, gcpConfiguration);
         }
 
-        public static IamServiceImpl.Builder newInstance(Monitor monitor, String gcpProjectId) {
-            return new Builder(monitor, gcpProjectId);
+        public static IamServiceImpl.Builder newInstance(Monitor monitor, GcpConfiguration gcpConfiguration) {
+            return new Builder(monitor, gcpConfiguration);
         }
 
         public Builder iamClientSupplier(Supplier<IAMClient> iamClientSupplier) {
@@ -123,7 +128,7 @@ public class IamServiceImpl implements IamService {
         }
 
         public IamServiceImpl build() {
-            Objects.requireNonNull(iamServiceImpl.gcpProjectId, "gcpProjectId");
+            Objects.requireNonNull(iamServiceImpl.gcpConfiguration, "gcpConfiguration");
             Objects.requireNonNull(iamServiceImpl.monitor, "monitor");
 
             if (iamServiceImpl.iamClientSupplier == null) {

--- a/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/iam/IamServiceImplTest.java
+++ b/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/iam/IamServiceImplTest.java
@@ -81,6 +81,13 @@ class IamServiceImplTest {
     }
 
     @Test
+    void testGetDefaultServiceAccount() {
+        var returnedServiceAccount = iamApi.getServiceAccount(null);
+
+        assertThat(returnedServiceAccount).isEqualTo(IamService.ADC_SERVICE_ACCOUNT);
+    }
+
+    @Test
     void testGetServiceAccountThatDoesntExist() {
         var name = ServiceAccountName.of(projectId, serviceAccountEmail).toString();
         var serviceAccount = ServiceAccount.newBuilder()
@@ -115,6 +122,17 @@ class IamServiceImplTest {
         when(accessTokenProvider.getAccessToken()).thenReturn(new GcpAccessToken(expectedTokenString, timeout));
 
         var accessToken = iamApi.createAccessToken(IamService.ADC_SERVICE_ACCOUNT);
+        assertThat(accessToken.getToken()).isEqualTo(expectedTokenString);
+        assertThat(accessToken.getExpiration()).isEqualTo(timeout);
+    }
+
+    @Test
+    void testCreateDefaultAccessTokenFromNullAccount() {
+        var expectedTokenString = "test-access-token";
+        long timeout = 3600;
+        when(accessTokenProvider.getAccessToken()).thenReturn(new GcpAccessToken(expectedTokenString, timeout));
+
+        var accessToken = iamApi.createAccessToken(null);
         assertThat(accessToken.getToken()).isEqualTo(expectedTokenString);
         assertThat(accessToken.getExpiration()).isEqualTo(timeout);
     }

--- a/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/iam/IamServiceImplTest.java
+++ b/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/iam/IamServiceImplTest.java
@@ -127,17 +127,6 @@ class IamServiceImplTest {
     }
 
     @Test
-    void testCreateDefaultAccessTokenFromNullAccount() {
-        var expectedTokenString = "test-access-token";
-        long timeout = 3600;
-        when(accessTokenProvider.getAccessToken()).thenReturn(new GcpAccessToken(expectedTokenString, timeout));
-
-        var accessToken = iamApi.createAccessToken(null);
-        assertThat(accessToken.getToken()).isEqualTo(expectedTokenString);
-        assertThat(accessToken.getExpiration()).isEqualTo(timeout);
-    }
-
-    @Test
     void testCreateDefaultAccessTokenError() {
         when(accessTokenProvider.getAccessToken()).thenReturn(null);
 

--- a/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/iam/IamServiceImplTest.java
+++ b/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/iam/IamServiceImplTest.java
@@ -114,7 +114,7 @@ class IamServiceImplTest {
         long timeout = 3600;
         when(accessTokenProvider.getAccessToken()).thenReturn(new GcpAccessToken(expectedTokenString, timeout));
 
-        var accessToken = iamApi.createDefaultAccessToken();
+        var accessToken = iamApi.createAccessToken(IamService.ADC_SERVICE_ACCOUNT);
         assertThat(accessToken.getToken()).isEqualTo(expectedTokenString);
         assertThat(accessToken.getExpiration()).isEqualTo(timeout);
     }
@@ -123,7 +123,7 @@ class IamServiceImplTest {
     void testCreateDefaultAccessTokenError() {
         when(accessTokenProvider.getAccessToken()).thenReturn(null);
 
-        var accessToken = iamApi.createDefaultAccessToken();
+        var accessToken = iamApi.createAccessToken(IamService.ADC_SERVICE_ACCOUNT);
         assertThat(accessToken).isNull();
     }
 

--- a/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisioner.java
+++ b/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisioner.java
@@ -75,12 +75,8 @@ public class BigQueryProvisioner implements Provisioner<BigQueryResourceDefiniti
 
         // TODO update target with the generated table name.
         try {
-            var serviceAccountName = resourceDefinition.getServiceAccountName();
-            if (serviceAccountName == null) {
-                serviceAccountName = gcpConfiguration.serviceAccountName();
-            }
-
-            var bigQuery = bqFactory.createBigQuery(serviceAccountName);
+            var serviceAccount = iamService.getServiceAccount(resourceDefinition.getServiceAccountName());
+            var bigQuery = bqFactory.createBigQuery(serviceAccount);
             var table = bigQuery.getTable(target.getTableId());
             if (table == null || !table.exists()) {
                 monitor.warning("BigQuery Provisioner table " + target.getTableName() + " DOESN'T exist");
@@ -88,7 +84,6 @@ public class BigQueryProvisioner implements Provisioner<BigQueryResourceDefiniti
             }
             monitor.info("BigQuery Provisioner table " + target.getTableName().toString() + " exists");
 
-            var serviceAccount = iamService.getServiceAccount(serviceAccountName);
             var token = iamService.createAccessToken(serviceAccount);
             monitor.info("BigQuery Provisioner token ready");
 

--- a/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisioner.java
+++ b/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisioner.java
@@ -21,7 +21,6 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedReso
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.ResourceDefinition;
 import org.eclipse.edc.gcp.bigquery.BigQueryTarget;
 import org.eclipse.edc.gcp.bigquery.service.BigQueryFactory;
-import org.eclipse.edc.gcp.common.GcpAccessToken;
 import org.eclipse.edc.gcp.common.GcpConfiguration;
 import org.eclipse.edc.gcp.common.GcpException;
 import org.eclipse.edc.gcp.common.GcpServiceAccount;
@@ -92,12 +91,11 @@ public class BigQueryProvisioner implements Provisioner<BigQueryResourceDefiniti
             }
             monitor.info("BigQuery Provisioner table " + target.getTableName().toString() + " exists");
 
-            GcpAccessToken token = null;
-
             if (serviceAccount == null) {
                 serviceAccount = IamService.ADC_SERVICE_ACCOUNT;
             }
-            token = iamService.createAccessToken(serviceAccount);
+
+            var token = iamService.createAccessToken(serviceAccount);
             monitor.info("BigQuery Provisioner token ready");
 
             var resource = getProvisionedResource(resourceDefinition, resourceName, tableName, serviceAccount);
@@ -109,10 +107,7 @@ public class BigQueryProvisioner implements Provisioner<BigQueryResourceDefiniti
     }
 
     private BigQueryProvisionedResource getProvisionedResource(BigQueryResourceDefinition resourceDefinition, String resourceName, String table, GcpServiceAccount serviceAccount) {
-        String serviceAccountName = null;
-        if (serviceAccount != null) {
-            serviceAccountName = serviceAccount.getName();
-        }
+        var serviceAccountName = serviceAccount.getName();
 
         return BigQueryProvisionedResource.Builder.newInstance()
             .properties(resourceDefinition.getProperties())

--- a/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisioner.java
+++ b/extensions/control-plane/provision/provision-bigquery/src/main/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisioner.java
@@ -38,7 +38,6 @@ import java.util.concurrent.CompletableFuture;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
 public class BigQueryProvisioner implements Provisioner<BigQueryResourceDefinition, BigQueryProvisionedResource> {
-    public static final GcpServiceAccount ADC_SERVICE_ACCOUNT = new GcpServiceAccount("adc-email", "adc-name", "application default");
     private final GcpConfiguration gcpConfiguration;
     private final BigQueryFactory bqFactory;
     private final IamService iamService;
@@ -95,12 +94,10 @@ public class BigQueryProvisioner implements Provisioner<BigQueryResourceDefiniti
 
             GcpAccessToken token = null;
 
-            if (serviceAccount != null) {
-                token = iamService.createAccessToken(serviceAccount);
-            } else {
-                serviceAccount = ADC_SERVICE_ACCOUNT;
-                token = iamService.createDefaultAccessToken();
+            if (serviceAccount == null) {
+                serviceAccount = IamService.ADC_SERVICE_ACCOUNT;
             }
+            token = iamService.createAccessToken(serviceAccount);
             monitor.info("BigQuery Provisioner token ready");
 
             var resource = getProvisionedResource(resourceDefinition, resourceName, tableName, serviceAccount);

--- a/extensions/control-plane/provision/provision-bigquery/src/test/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisionerTest.java
+++ b/extensions/control-plane/provision/provision-bigquery/src/test/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisionerTest.java
@@ -172,10 +172,8 @@ class BigQueryProvisionerTest {
             // When using defuault credentials, createBigQuery is executed passing a null argument.
             when(bqFactory.createBigQuery(null)).thenReturn(bigQuery);
 
-            serviceAccount = BigQueryProvisioner.ADC_SERVICE_ACCOUNT;
+            serviceAccount = IamService.ADC_SERVICE_ACCOUNT;
             serviceAccountName = serviceAccount.getName();
-
-            when(iamService.createDefaultAccessToken()).thenReturn(token);
         } else {
             // Using credentials specified in the transfer request.
             resourceDefinitionBuilder.property(BigQueryServiceSchema.SERVICE_ACCOUNT_NAME, serviceAccountName);
@@ -185,9 +183,8 @@ class BigQueryProvisionerTest {
 
             serviceAccount = new GcpServiceAccount(TEST_EMAIL, serviceAccountName, TEST_DESCRIPTION);
             when(iamService.getServiceAccount(serviceAccountName)).thenReturn(serviceAccount);
-
-            when(iamService.createAccessToken(serviceAccount)).thenReturn(token);
         }
+        when(iamService.createAccessToken(serviceAccount)).thenReturn(token);
 
         var resourceDefinition = resourceDefinitionBuilder.build();
         var expectedResource = BigQueryProvisionedResource.Builder.newInstance()
@@ -218,7 +215,7 @@ class BigQueryProvisionerTest {
             verify(iamService).getServiceAccount(serviceAccountName);
             verify(iamService).createAccessToken(serviceAccount);
         } else {
-            verify(iamService).createDefaultAccessToken();
+            verify(iamService).createAccessToken(serviceAccount);
         }
 
         var content = assertThat(result).succeedsWithin(1, SECONDS)

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisioner.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisioner.java
@@ -86,11 +86,10 @@ public class GcsProvisioner implements Provisioner<GcsResourceDefinition, GcsPro
             var serviceAccountName = getServiceAccountName(resourceDefinition);
             if (serviceAccountName != null) {
                 serviceAccount = iamService.getServiceAccount(serviceAccountName);
-                token = iamService.createAccessToken(serviceAccount);
             } else {
-                serviceAccount = new GcpServiceAccount("adc-email", "adc-name", "application default");
-                token = iamService.createDefaultAccessToken();
+                serviceAccount = IamService.ADC_SERVICE_ACCOUNT;
             }
+            token = iamService.createAccessToken(serviceAccount);
 
             var resource = getProvisionedResource(resourceDefinition, resourceName, bucketName, serviceAccount);
 

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisioner.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisioner.java
@@ -20,7 +20,6 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.DeprovisionedRe
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionResponse;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedResource;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.ResourceDefinition;
-import org.eclipse.edc.gcp.common.GcpAccessToken;
 import org.eclipse.edc.gcp.common.GcpConfiguration;
 import org.eclipse.edc.gcp.common.GcpException;
 import org.eclipse.edc.gcp.common.GcpServiceAccount;
@@ -81,16 +80,14 @@ public class GcsProvisioner implements Provisioner<GcsResourceDefinition, GcsPro
             var bucket = storageService.getOrCreateBucket(bucketName, bucketLocation);
 
             GcpServiceAccount serviceAccount = null;
-            GcpAccessToken token = null;
-
             var serviceAccountName = getServiceAccountName(resourceDefinition);
             if (serviceAccountName != null) {
                 serviceAccount = iamService.getServiceAccount(serviceAccountName);
             } else {
                 serviceAccount = IamService.ADC_SERVICE_ACCOUNT;
             }
-            token = iamService.createAccessToken(serviceAccount);
 
+            var token = iamService.createAccessToken(serviceAccount);
             var resource = getProvisionedResource(resourceDefinition, resourceName, bucketName, serviceAccount);
 
             var response = ProvisionResponse.Builder.newInstance().resource(resource).secretToken(token).build();

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisioner.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisioner.java
@@ -75,19 +75,13 @@ public class GcsProvisioner implements Provisioner<GcsResourceDefinition, GcsPro
 
         var bucketLocation = resourceDefinition.getLocation();
         var resourceName = bucketName + "-bucket";
-        var processId = resourceDefinition.getTransferProcessId();
         try {
             var bucket = storageService.getOrCreateBucket(bucketName, bucketLocation);
-            var serviceAccountName = resourceDefinition.getServiceAccountName();
-            if (serviceAccountName == null) {
-                serviceAccountName = gcpConfiguration.serviceAccountName();
-            }
-
-            var serviceAccount = iamService.getServiceAccount(serviceAccountName);
+            var serviceAccount = iamService.getServiceAccount(resourceDefinition.getServiceAccountName());
             var token = iamService.createAccessToken(serviceAccount);
             var resource = getProvisionedResource(resourceDefinition, resourceName, bucketName, serviceAccount);
-
             var response = ProvisionResponse.Builder.newInstance().resource(resource).secretToken(token).build();
+
             return CompletableFuture.completedFuture(StatusResult.success(response));
         } catch (GcpException gcpException) {
             return completedFuture(StatusResult.failure(ResponseStatus.FATAL_ERROR, gcpException.toString()));

--- a/extensions/control-plane/provision/provision-gcs/src/test/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerTest.java
+++ b/extensions/control-plane/provision/provision-gcs/src/test/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerTest.java
@@ -83,10 +83,13 @@ class GcsProvisionerTest {
 
         when(storageServiceMock.getOrCreateBucket(bucketName, bucketLocation)).thenReturn(bucket);
         when(storageServiceMock.isEmpty(bucketName)).thenReturn(true);
-        when(iamServiceMock.createDefaultAccessToken()).thenReturn(token);
+        when(iamServiceMock.createAccessToken(IamService.ADC_SERVICE_ACCOUNT)).thenReturn(token);
         doNothing().when(storageServiceMock).addProviderPermissions(bucket, serviceAccount);
 
         var response = provisioner.provision(resourceDefinition, testPolicy).join().getContent();
+
+        verify(storageServiceMock).getOrCreateBucket(bucketName, bucketLocation);
+        verify(iamServiceMock).createAccessToken(IamService.ADC_SERVICE_ACCOUNT);
 
         assertThat(response.getResource()).isInstanceOfSatisfying(GcsProvisionedResource.class, resource -> {
             assertThat(resource.getId()).isEqualTo(resourceDefinitionId);
@@ -97,9 +100,6 @@ class GcsProvisionerTest {
         assertThat(response.getSecretToken()).isInstanceOfSatisfying(GcpAccessToken.class, secretToken -> {
             assertThat(secretToken.getToken()).isEqualTo("token");
         });
-
-        verify(storageServiceMock).getOrCreateBucket(bucketName, bucketLocation);
-        verify(iamServiceMock).createDefaultAccessToken();
     }
 
     @Test
@@ -155,7 +155,7 @@ class GcsProvisionerTest {
         assertThat(response.failed()).isFalse();
 
         verify(storageServiceMock).getOrCreateBucket(bucketName, bucketLocation);
-        verify(iamServiceMock, times(1)).createDefaultAccessToken();
+        verify(iamServiceMock, times(1)).createAccessToken(IamService.ADC_SERVICE_ACCOUNT);
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Removed method createDefaultAccessToken from IamService. Access token from ADC generated via createAccessToken with null or ADC_SERVICE_ACCOUNT parameter.

## Why it does that

Simplify the API and delegate IamService to generate appropriate token.
