### PR TITLE
fix: impersonated credentials generation and provisioner test

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -189,9 +189,9 @@ maven/mavencentral/org.apache.maven.doxia/doxia-sink-api/1.12.0, Apache-2.0, app
 maven/mavencentral/org.apache.xbean/xbean-reflect/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
-maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.77, MIT, approved, #11593
-maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.77, MIT AND CC0-1.0, approved, #11595
-maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.77, MIT, approved, #11596
+maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.78, MIT, approved, #14235
+maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.78, MIT AND CC0-1.0, approved, #14237
+maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.78, MIT, approved, #14238
 maven/mavencentral/org.checkerframework/checker-compat-qual/2.5.6, GPL-2.0-only with Classpath-Exception-2.0, approved, #11598
 maven/mavencentral/org.checkerframework/checker-qual/3.37.0, MIT, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, clearlydefined

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/service/BigQueryFactoryImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/bigquery/service/BigQueryFactoryImpl.java
@@ -47,7 +47,7 @@ public class BigQueryFactoryImpl implements BigQueryFactory {
                     "' using service account '" + serviceAccount.getName() + "'");
             credentials = ImpersonatedCredentials.create(
                 credentials,
-                serviceAccount.getName(),
+                serviceAccount.getEmail(),
                 null,
                 Arrays.asList("https://www.googleapis.com/auth/bigquery"),
                 3600);

--- a/extensions/control-plane/provision/provision-bigquery/src/test/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisionerTest.java
+++ b/extensions/control-plane/provision/provision-bigquery/src/test/java/org/eclipse/edc/connector/provision/gcp/BigQueryProvisionerTest.java
@@ -219,8 +219,11 @@ class BigQueryProvisionerTest {
 
     @Test
     void provisionFailsIfTableDoesntExist() throws IOException {
+        var serviceAccount = new GcpServiceAccount(TEST_EMAIL, TEST_SERVICE_ACCOUNT_NAME, TEST_DESCRIPTION);
+        when(iamService.getServiceAccount(null)).thenReturn(serviceAccount);
+
         var bqFactory = mock(BigQueryFactory.class);
-        when(bqFactory.createBigQuery(null)).thenReturn(bigQuery);
+        when(bqFactory.createBigQuery(serviceAccount)).thenReturn(bigQuery);
 
         var bigQueryProvisioner = new BigQueryProvisioner(gcpConfiguration, bqFactory, iamService, monitor);
 


### PR DESCRIPTION
## What this PR changes/adds

- impersonated credentials for BigQuery passing email instead of name
- provisioner test passing non-null service account

## Why it does that

Fixing test and impersonation
