### PR TITLE
fix(ci): set version before tests, publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,6 +50,8 @@ jobs:
     needs: [ Secrets-Presence, Determine-Version ]
     uses: ./.github/workflows/verify.yaml
     secrets: inherit
+    with:
+      version: ${{ needs.Determine-Version.outputs.VERSION }}
 
   Publish-Artefacts:
     runs-on: ubuntu-latest
@@ -68,6 +70,14 @@ jobs:
         name: "Import GPG Key"
         with:
           gpg-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
+
+      - name: Set correct version
+        env:
+          VERSION: ${{ needs.Determine-Version.outputs.VERSION }}
+        run: |
+          existingVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}') 
+          grep -rlz "$existingVersion" . --exclude=\*.{sh,bin} | xargs sed -i "s/$existingVersion/$VERSION/g"
+
 
       - name: "Publish To OSSRH/MavenCentral"
         if: |

--- a/.github/workflows/release-tech-gcp.yml
+++ b/.github/workflows/release-tech-gcp.yml
@@ -70,7 +70,8 @@ jobs:
   Bump-Version:
     name: 'Update release version'
     # cannot use the workflow-level env yet as it does not yet exist, must take output from previous job
-    if: ${{ !endsWith( needs.Prepare-Release.outputs.edc-version, '-SNAPSHOT') }}
+    # only bump the version for releases, no snapshots, no bugfixes/patches
+    if: ${{ endsWith( needs.Prepare-Release.outputs.edc-version, '.0') }}
     needs: [ Prepare-Release, Github-Release ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -2,7 +2,17 @@ name: Run Tests
 
 on:
   workflow_call:
+    inputs:
+      version:
+        required: false
+        type: string
+        description: optional version of upstream EDC components to use
   workflow_dispatch:
+    inputs:
+      version:
+        required: false
+        type: string
+        description: optional version of upstream EDC components to use
   push:
   pull_request:
     branches: [ main ]
@@ -26,6 +36,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
+      - name: "Set upstream EDC version"
+        run: |
+          # update EDC dependencies in the version catalog
+          if [ ! -z ${{ env.VERSION }} ]; then
+            echo "set EDC version to ${{ env.VERSION }}"
+            existingVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}') 
+            sed -i "s/$existingVersion/${{ env.VERSION }}/g" gradle/libs.versions.toml
+
+            # some debug print
+            head -20 gradle/libs.versions.toml
+          fi
 
       - name: Run Checkstyle
         run: ./gradlew checkstyleMain checkstyleTest
@@ -37,6 +58,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
+      - name: "Set upstream EDC version"
+        run: |
+          # update EDC dependencies in the version catalog
+          if [ ! -z ${{ env.VERSION }} ]; then
+            echo "set EDC version to ${{ env.VERSION }}"
+            existingVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}') 
+            sed -i "s/$existingVersion/${{ env.VERSION }}/g" gradle/libs.versions.toml
+          
+            # some debug print
+            head -20 gradle/libs.versions.toml
+          fi
 
       - name: Run unit tests
         uses: eclipse-edc/.github/.github/actions/run-tests@main
@@ -50,6 +82,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
+      - name: "Set upstream EDC version"
+        run: |
+          # update EDC dependencies in the version catalog
+          if [ ! -z ${{ env.VERSION }} ]; then
+            echo "set EDC version to ${{ env.VERSION }}"
+            existingVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}') 
+            sed -i "s/$existingVersion/${{ env.VERSION}}/g" gradle/libs.versions.toml
+          
+            # some debug print
+            head -20 gradle/libs.versions.toml
+          fi
 
       - name: Component Tests
         uses: eclipse-edc/.github/.github/actions/run-tests@main
@@ -61,6 +104,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
+      - name: "Set upstream EDC version"
+        run: |
+          # update EDC dependencies in the version catalog
+          if [ ! -z ${{ env.VERSION }} ]; then
+            echo "set EDC version to ${{ env.VERSION }}"
+            existingVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}') 
+            sed -i "s/$existingVersion/${{ env.VERSION }}/g" gradle/libs.versions.toml
+          
+            # some debug print
+            head -20 gradle/libs.versions.toml
+          fi
 
       - name: End to End Integration Tests
         uses: eclipse-edc/.github/.github/actions/run-tests@main
@@ -74,6 +128,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
+      - name: "Set upstream EDC version"
+        run: |
+          # update EDC dependencies in the version catalog
+          if [ ! -z ${{ env.VERSION }} ]; then
+            echo "set EDC version to ${{ env.VERSION }}"
+            existingVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}') 
+            sed -i "s/$existingVersion/${{ env.VERSION }}/g" gradle/libs.versions.toml
+          
+            # some debug print
+            head -20 gradle/libs.versions.toml
+          fi
 
       - name: Component Tests
         uses: eclipse-edc/.github/.github/actions/run-tests@main

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -4,14 +4,17 @@ maven/mavencentral/com.apicatalog/copper-multicodec/0.1.1, Apache-2.0, approved,
 maven/mavencentral/com.apicatalog/iron-verifiable-credentials/0.14.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.4.0, Apache-2.0, approved, #15200
+maven/mavencentral/com.apicatalog/titanium-json-ld/1.4.1, Apache-2.0, approved, #15200
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.10.3, Apache-2.0, approved, CQ21280
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.2, Apache-2.0, approved, #11606
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.17.0, Apache-2.0, approved, #13672
+maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.17.1, Apache-2.0, approved, #13672
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.17.2, Apache-2.0, approved, #13672
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.17.0, , approved, #13665
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.17.2, , approved, #13665
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.2, Apache-2.0, approved, #11605
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.17.0, Apache-2.0, approved, #13671
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.17.1, Apache-2.0, approved, #13671
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.17.2, Apache-2.0, approved, #13671
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.16.2, Apache-2.0, approved, #11855
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.17.2, Apache-2.0, approved, #13669
@@ -22,12 +25,15 @@ maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.17.2
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.17.2, Apache-2.0, approved, #14194
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.16.2, Apache-2.0, approved, #11858
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.17.2, Apache-2.0, approved, #14195
-maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.17.0, Apache-2.0, approved, #13668
+maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.17.1, Apache-2.0, approved, #13668
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.17.2, Apache-2.0, approved, #13668
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.17.2, Apache-2.0, approved, #14162
 maven/mavencentral/com.github.docker-java/docker-java-api/3.3.6, Apache-2.0, approved, #10346
+maven/mavencentral/com.github.docker-java/docker-java-api/3.4.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.6, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #15251
+maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.4.0, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #15745
 maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.6, Apache-2.0, approved, #7942
+maven/mavencentral/com.github.docker-java/docker-java-transport/3.4.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.android/annotations/4.1.1.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.api-client/google-api-client/2.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.api-client/google-api-client/2.4.0, Apache-2.0, approved, clearlydefined
@@ -74,7 +80,7 @@ maven/mavencentral/com.google.cloud/libraries-bom/26.38.0, , restricted, clearly
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, CC-BY-2.5, approved, #15220
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
 maven/mavencentral/com.google.code.gson/gson/2.8.9, Apache-2.0, approved, CQ23496
-maven/mavencentral/com.google.crypto.tink/tink/1.13.0, Apache-2.0, approved, #14502
+maven/mavencentral/com.google.crypto.tink/tink/1.14.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.18.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.23.0, Apache-2.0, approved, #11083
@@ -101,7 +107,6 @@ maven/mavencentral/com.google.j2objc/j2objc-annotations/2.8, Apache-2.0, approve
 maven/mavencentral/com.google.j2objc/j2objc-annotations/3.0.0, Apache-2.0, approved, #13676
 maven/mavencentral/com.google.oauth-client/google-oauth-client/1.35.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.protobuf/protobuf-java-util/3.25.3, BSD-3-Clause, approved, clearlydefined
-maven/mavencentral/com.google.protobuf/protobuf-java/3.25.1, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.google.protobuf/protobuf-java/3.25.3, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.google.re2j/re2j/1.7, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.40, Apache-2.0, approved, #15156
@@ -132,7 +137,7 @@ maven/mavencentral/io.grpc/grpc-core/1.62.2, Apache-2.0, approved, clearlydefine
 maven/mavencentral/io.grpc/grpc-googleapis/1.62.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.grpc/grpc-grpclb/1.62.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.grpc/grpc-inprocess/1.62.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.grpc/grpc-netty-shaded/1.62.2, Apache-2.0, restricted, clearlydefined
+maven/mavencentral/io.grpc/grpc-netty-shaded/1.62.2, Apache-2.0, approved, #15793
 maven/mavencentral/io.grpc/grpc-protobuf-lite/1.62.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.grpc/grpc-protobuf/1.62.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.grpc/grpc-rls/1.62.2, Apache-2.0, approved, clearlydefined
@@ -182,7 +187,6 @@ maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.15, Apache-2.0, approved,
 maven/mavencentral/net.bytebuddy/byte-buddy/1.12.21, Apache-2.0 AND BSD-3-Clause, approved, #1811
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.1, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.15, Apache-2.0 AND BSD-3-Clause, approved, #7163
-maven/mavencentral/net.bytebuddy/byte-buddy/1.14.16, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.18, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.9, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #15196
@@ -222,9 +226,8 @@ maven/mavencentral/org.apache.maven.doxia/doxia-sink-api/1.12.0, Apache-2.0, app
 maven/mavencentral/org.apache.xbean/xbean-reflect/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.assertj/assertj-core/3.24.2, Apache-2.0, approved, #6161
-maven/mavencentral/org.assertj/assertj-core/3.26.0, Apache-2.0, approved, #14886
 maven/mavencentral/org.assertj/assertj-core/3.26.3, Apache-2.0, approved, #14886
-maven/mavencentral/org.awaitility/awaitility/4.2.1, Apache-2.0, approved, #14178
+maven/mavencentral/org.awaitility/awaitility/4.2.2, Apache-2.0, approved, #14178
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.78.1, MIT, approved, #14434
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.78.1, MIT AND CC0-1.0, approved, #14433
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.78.1, MIT, approved, #14435
@@ -319,6 +322,7 @@ maven/mavencentral/org.eclipse.edc/json-ld/0.8.2-SNAPSHOT, Apache-2.0, approved,
 maven/mavencentral/org.eclipse.edc/json-lib/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/junit-base/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/junit/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jwt-signer-spi/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jwt-spi/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/keys-lib/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/keys-spi/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -374,21 +378,21 @@ maven/mavencentral/org.eclipse.jetty/jetty-servlet/11.0.22, EPL-2.0 OR Apache-2.
 maven/mavencentral/org.eclipse.jetty/jetty-util/11.0.22, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.22, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.22, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.parsson/parsson/1.1.6, EPL-2.0, approved, ee4j.parsson
+maven/mavencentral/org.eclipse.parsson/parsson/1.1.7, EPL-2.0, approved, ee4j.parsson
 maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-api/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-locator/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-utils/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/osgi-resource-locator/1.0.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
-maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet-core/3.1.7, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet/3.1.7, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.core/jersey-client/3.1.7, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.core/jersey-common/3.1.7, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.core/jersey-server/3.1.7, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.ext/jersey-entity-filtering/3.1.7, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2/3.1.7, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson/3.1.7, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart/3.1.7, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet-core/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-client/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-common/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-server/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.ext/jersey-entity-filtering/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
 maven/mavencentral/org.glassfish/jakarta.json/2.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jsonp
 maven/mavencentral/org.hamcrest/hamcrest-core/1.3, BSD-2-Clause, approved, CQ11429
 maven/mavencentral/org.hamcrest/hamcrest/2.1, BSD-3-Clause, approved, clearlydefined
@@ -437,7 +441,9 @@ maven/mavencentral/org.slf4j/slf4j-api/1.7.36, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
 maven/mavencentral/org.testcontainers/gcloud/1.19.8, MIT, approved, clearlydefined
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.8, MIT, approved, #10344
+maven/mavencentral/org.testcontainers/junit-jupiter/1.20.1, MIT, approved, clearlydefined
 maven/mavencentral/org.testcontainers/testcontainers/1.19.8, MIT, approved, #15203
+maven/mavencentral/org.testcontainers/testcontainers/1.20.1, MIT, approved, #15747
 maven/mavencentral/org.threeten/threeten-extra/1.8.0, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.threeten/threetenbp/1.6.9, BSD-3-Clause, approved, #6750
 maven/mavencentral/org.xmlresolver/xmlresolver/5.2.2, Apache-2.0, approved, clearlydefined


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a temporary fix to update the `gradle/libs.version.toml` version catalog before a version is published. 
Specifically, it passes the version string to `verify.yaml`, so that tests are executed using the given upstream EDC modules, and it updates `gradle.properties`, `gradle/libs.versions.toml` and `DEPENDENCIES` before the Maven artefacts are published.

In addition, the release job (`release-tech-aws.yaml`) only bumps the version if it was a "release" version (not a hotfix/bugfix or a snapshot).

## Why it does that

employ a temporary fix until a restructuring of the release workflow can be implemented.

## Further notes

I intentionally did not extract the `sed` command in a re-usable action, because it is a temporary fix anyway, and it is better if it sticks out like a sore thumb

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._


